### PR TITLE
Add rackunit integration for expect tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-Expect testing for Racket
+# recspecs
+
+`recspecs` provides a lightweight expect testing facility for Racket. It is
+inspired by [Jane Street's `expect_test` for OCaml](https://github.com/janestreet/expect_test)
+and the [`expect-test` crate](https://github.com/greyblake/expect-test) for Rust.
+
+Expect tests record the output of expressions directly in the source file.
+Each `expect` form expands to a small RackUnit test that compares the
+captured output against the recorded expectation. When the environment
+variable `RECSPECS_UPDATE` is set, failing expectations are automatically
+updated in the file instead of causing a failure.
+
+## Example
+
+```racket
+#lang racket
+(require recspecs)
+
+(expect
+  (begin
+    (displayln "hello")
+    (displayln (+ 1 2)))
+  "hello\n3\n")
+```
+
+Run the file with `raco test` (or any RackUnit runner) to execute the
+expectations. If they fail and you want to update the saved output, set
+`RECSPECS_UPDATE`:
+
+```console
+$ RECSPECS_UPDATE=1 raco test my-test.rkt
+```
+
+## Status
+
+This library is experimental but demonstrates the core API.  More features,
+like integration with rackunit and pretty diff output, can be added in the
+future.
+

--- a/main.rkt
+++ b/main.rkt
@@ -1,1 +1,57 @@
 #lang racket/base
+
+(require racket/file
+         racket/port
+         rackunit
+         (for-syntax racket/base
+                     syntax/parse))
+
+(provide expect)
+
+;; Returns #t when expectations should be updated instead of reported as
+;; failures. The update mode is enabled when the environment variable
+;; RECSPECS_UPDATE is set to any value.
+(define (update-mode?)
+  (and (getenv "RECSPECS_UPDATE") #t))
+
+(define (update-file path pos span new-str)
+  ;; Replace the expectation string located at [pos, pos+span) in the file
+  ;; at `path` with the printed representation of `new-str`.
+  (define bs (file->bytes path))
+  (define before (subbytes bs 0 pos))
+  (define after (subbytes bs (+ pos span)))
+  (define new-bs (bytes-append before
+                               (string->bytes/utf-8 (format "~s" new-str))
+                               after))
+  (call-with-output-file path
+    #:exists 'truncate/replace
+    (lambda (out)
+      (write-bytes new-bs out))))
+
+(define (run-expect thunk expected path pos span)
+  ;; Returns a rackunit test that evaluates `thunk`, captures anything printed
+  ;; to the current output port and compares it to `expected`. When update mode
+  ;; is enabled and the values differ, the source file is rewritten instead of
+  ;; failing the test.
+  (define name (if path
+                   (format "~a:~a" path pos)
+                   "expect"))
+  (test-case name
+    (define actual (with-output-to-string thunk))
+    (if (and path (update-mode?) (not (string=? actual expected)))
+        (begin (update-file path pos span actual)
+               (printf "Updated expectation in ~a\n" path))
+        (check-equal? actual expected))))
+
+(define-syntax (expect stx)
+  (syntax-parse stx
+    [(_ expr expected:str)
+     (define src (syntax-source #'expected))
+     (define pos (or (syntax-position #'expected) 0))
+     (define span (or (syntax-span #'expected)
+                      (string-length (syntax-e #'expected))))
+     #`(run-expect (lambda () expr)
+                   expected
+                   #,(and src (path->string src))
+                   #,pos
+                   #,span)]))

--- a/main.scrbl
+++ b/main.scrbl
@@ -2,3 +2,23 @@
 
 @title{recspecs: Expect Testing for Racket}
 @defmodule[recspecs]
+
+The @racket[expect] form captures anything printed to the current output
+port while evaluating an expression and compares it to a string literal
+stored directly in the source file.  Each use expands to a
+RackUnit @racket[test-case].  When the environment variable
+@tt{RECSPECS_UPDATE} is set and the expectation does not match, the file
+is rewritten with the new output instead of failing the test.
+
+@defform[(expect expr expected-str)]{
+Evaluates @racket[expr] and checks that the captured output is equal to
+@racket[expected-str]. If they differ and @tt{RECSPECS_UPDATE} is set,
+the expectation string in the source file is replaced with the new
+value.  Otherwise the test case fails.
+}
+
+@racketblock[
+  (require recspecs)
+  (expect (displayln "hello") "hello\n")]
+
+


### PR DESCRIPTION
## Summary
- integrate `expect` with RackUnit by returning a test case
- document RackUnit usage in README and manual
- allow updating expectations via `RECSPECS_UPDATE` without failing tests

## Testing
- `/workspace/racket/bin/raco make main.rkt main.scrbl`


------
https://chatgpt.com/codex/tasks/task_e_6843548855048328a5cb604be870a8f6