### PR TITLE
Update CI workflow with setup-plt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: full
           architecture: x64
       - name: Install package
-        run: raco pkg install --auto --batch --name recspecs .
+        run: raco pkg install --auto
       - name: Build package
         run: raco setup --check-pkg-deps --unused-pkg-deps recspecs
       - name: Run tests


### PR DESCRIPTION
## Summary
- switch to `bogdan/setup-plt` for Racket setup
- install the package, build it, and run tests in CI

## Testing
- `../racket/bin/raco test -x -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684359895fb08328ab869d743a13c5bc