### PR TITLE
Implement colorized diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ RECSPECS_UPDATE=1 raco test my-test.rkt
 
 ## Status
 
-This library is experimental but demonstrates the core API.  More features,
-like integration with rackunit and pretty diff output, can be added in the
-future.
+This library is experimental but demonstrates the core API. It now shows a
+colorized diff when expectations fail. Further features like tighter
+integration with rackunit can be added in the future.
 

--- a/main.rkt
+++ b/main.rkt
@@ -2,6 +2,10 @@
 
 (require racket/file
          racket/port
+         racket/list
+         racket/string
+         racket/vector
+         racket/match
          rackunit
          (for-syntax racket/base
                      syntax/parse))
@@ -28,6 +32,62 @@
     (lambda (out)
       (write-bytes new-bs out))))
 
+;; Split a string into lines without dropping trailing empty lines
+(define (string->lines s)
+  (define lines (regexp-split #px"\n" s))
+  (if (regexp-match? #px"\n$" s)
+      (append lines '(""))
+      lines))
+
+;; Compute a simple diff between two sequences of lines using the
+;; longest common subsequence algorithm.
+(define (lines-diff a-lines b-lines)
+  (define m (length a-lines))
+  (define n (length b-lines))
+  (define tbl
+    (for/vector ([i (in-range (add1 m))])
+      (make-vector (add1 n) 0)))
+  ;; fill table
+  (for ([i (in-range m)])
+    (for ([j (in-range n)])
+      (vector-set! (vector-ref tbl (add1 i)) (add1 j)
+                   (if (string=? (list-ref a-lines i) (list-ref b-lines j))
+                       (add1 (vector-ref (vector-ref tbl i) j))
+                       (max (vector-ref (vector-ref tbl i) (add1 j))
+                            (vector-ref (vector-ref tbl (add1 i)) j))))))
+  ;; backtrack
+  (define diffs '())
+  (let loop ([i m] [j n])
+    (cond
+      [(and (> i 0) (> j 0)
+             (string=? (list-ref a-lines (sub1 i)) (list-ref b-lines (sub1 j))))
+       (set! diffs (cons (cons 'same (list-ref a-lines (sub1 i))) diffs))
+       (loop (sub1 i) (sub1 j))]
+      [(and (> j 0)
+            (or (= i 0)
+                (>= (vector-ref (vector-ref tbl i) (sub1 j))
+                    (vector-ref (vector-ref tbl (sub1 i)) j))))
+       (set! diffs (cons (cons 'add (list-ref b-lines (sub1 j))) diffs))
+       (loop i (sub1 j))]
+      [(> i 0)
+       (set! diffs (cons (cons 'del (list-ref a-lines (sub1 i))) diffs))
+       (loop (sub1 i) j)]))
+  diffs)
+
+;; Render a diff as a string with ANSI color codes
+(define (pretty-diff expected actual)
+  (define diffs (lines-diff (string->lines expected)
+                            (string->lines actual)))
+  (define (color c s)
+    (string-append "\x1b[" c "m" s "\x1b[0m"))
+  (string-join
+   (for/list ([d diffs])
+     (match d
+       [(cons 'same l) (string-append "  " l)]
+       [(cons 'add l) (color "32" (string-append "+ " l))]
+       [(cons 'del l) (color "31" (string-append "- " l))]))
+   "\n"))
+
 (define (run-expect thunk expected path pos span)
   ;; Returns a rackunit test that evaluates `thunk`, captures anything printed
   ;; to the current output port and compares it to `expected`. When update mode
@@ -38,10 +98,16 @@
                    "expect"))
   (test-case name
     (define actual (with-output-to-string thunk))
-    (if (and path (update-mode?) (not (string=? actual expected)))
-        (begin (update-file path pos span actual)
-               (printf "Updated expectation in ~a\n" path))
-        (check-equal? actual expected))))
+    (cond
+      [(and path (update-mode?) (not (string=? actual expected)))
+       (update-file path pos span actual)
+       (printf "Updated expectation in ~a\n" path)]
+      [(string=? actual expected)
+       (check-equal? actual expected)]
+      [else
+       (displayln "Diff:" (current-error-port))
+       (displayln (pretty-diff expected actual) (current-error-port))
+       (check-equal? actual expected)])))
 
 (define-syntax (expect stx)
   (syntax-parse stx

--- a/main.scrbl
+++ b/main.scrbl
@@ -8,7 +8,9 @@ port while evaluating an expression and compares it to a string literal
 stored directly in the source file.  Each use expands to a
 RackUnit @racket[test-case].  When the environment variable
 @tt{RECSPECS_UPDATE} is set and the expectation does not match, the file
-is rewritten with the new output instead of failing the test.
+is rewritten with the new output instead of failing the test.  When
+@tt{RECSPECS_UPDATE} is not set and the expectation fails, a colorized
+diff is printed to help understand the mismatch.
 
 @defform[(expect expr expected-str)]{
 Evaluates @racket[expr] and checks that the captured output is equal to


### PR DESCRIPTION
## Summary
- show colorized diffs when expectations fail
- document diff output in README and docs

## Testing
- `raco test -x .`
- `raco test main.rkt`


------
https://chatgpt.com/codex/tasks/task_e_684362c4ddc48328b667859fd929e5e9