### PR TITLE
Add basic expect test suite

### DIFF
--- a/tests/expect.rkt
+++ b/tests/expect.rkt
@@ -1,0 +1,17 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define expect-tests
+  (test-suite
+   "expect-tests"
+   (expect (display "hello") "hello")
+   (expect (begin
+             (displayln "hello")
+             (displayln (+ 1 2)))
+           "hello\n3\n")
+   (expect (void) "")))
+
+(module+ test
+  (run-tests expect-tests))


### PR DESCRIPTION
## Summary
- add a simple RackUnit test suite covering the `expect` macro

## Testing
- `raco setup --check-pkg-deps --unused-pkg-deps recspecs`
- `raco test -x -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_6844fb3b4e908328aef1afa6bcf8abe0