### PR TITLE
Add expect-file and expect-exn forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ captured output against the recorded expectation. When the environment
 variable `RECSPECS_UPDATE` is set, failing expectations are automatically
 updated in the file instead of causing a failure.
 
+Additional forms mirror features from the OCaml and Rust libraries:
+
+* `expect-file` compares the output against the contents of a separate file
+  and rewrites that file when updating.
+* `expect-exn` checks that an expression raises an exception with a given
+  message.
+
 ## Example
 
 ```racket
@@ -34,6 +41,7 @@ $ RECSPECS_UPDATE=1 raco test my-test.rkt
 ## Status
 
 This library is experimental but demonstrates the core API. It now shows a
-colorized diff when expectations fail. Further features like tighter
-integration with rackunit can be added in the future.
+colorized diff when expectations fail and supports file based expectations
+and exception checks. Further features like tighter integration with
+rackunit can be added in the future.
 

--- a/main.scrbl
+++ b/main.scrbl
@@ -23,4 +23,14 @@ value.  Otherwise the test case fails.
   (require recspecs)
   (expect (displayln "hello") "hello\n")]
 
+@defform[(expect-file expr path-str)]{
+Reads the expectation from @racket[path-str] instead of embedding it in the
+source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.
+}
+
+@defform[(expect-exn expr expected-str)]{
+Checks that @racket[expr] raises an exception whose message matches
+@racket[expected-str]. The message is updated when update mode is enabled.
+}
+
 


### PR DESCRIPTION
## Summary
- expand `expect` system with additional features inspired by other expect testing libraries
- add `expect-file` for file-based expectations
- add `expect-exn` for checking exception messages
- document new forms in the manual and README

## Testing
- `raco make main.rkt`
- `raco make main.scrbl`
- `raco test main.rkt`


------
https://chatgpt.com/codex/tasks/task_e_6844fb596dfc83288c2e1222c55c06e3