### PR TITLE
Add flexible whitespace matching

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -14,6 +14,26 @@
          expect-file
          expect-exn)
 
+;; Normalize a string by trimming leading and trailing whitespace and removing
+;; common indentation from all lines. This is used when comparing expectation
+;; strings in non strict mode.
+(define (normalize-string s)
+  (define trimmed (string-trim s))
+  (define lines (regexp-split #px"\r?\n" trimmed))
+  (define non-empty-lines
+    (filter (lambda (l) (regexp-match? #px"\\S" l)) lines))
+  (define min-indent
+    (if (null? non-empty-lines)
+        0
+        (apply min
+               (map (lambda (l)
+                      (string-length (car (regexp-match #px"^[ \t]*" l))))
+                    non-empty-lines))))
+  (define dedented
+    (for/list ([l lines])
+      (string-trim (substring l (min (string-length l) min-indent)))))
+  (string-join dedented "\n"))
+
 ;; Returns #t when expectations should be updated instead of reported as
 ;; failures. The update mode is enabled when the environment variable
 ;; RECSPECS_UPDATE is set to any value. When the optional
@@ -105,7 +125,8 @@
    "\n"))
 
 (define (run-expect thunk expected path pos span
-                    [update update-file])
+                    [update update-file]
+                    #:strict [strict? #f])
   ;; Returns a rackunit test that evaluates `thunk`, captures anything printed
   ;; to the current output port and compares it to `expected`. When update mode
   ;; is enabled and the values differ, the source file is rewritten instead of
@@ -115,19 +136,25 @@
                    "expect"))
   (test-case name
     (define actual (with-output-to-string thunk))
+    (define equal?
+      (if strict?
+          (string=? actual expected)
+          (string=? (normalize-string actual)
+                    (normalize-string expected))))
     (cond
-      [(and path (update-mode? name) (not (string=? actual expected)))
+      [(and path (update-mode? name) (not equal?))
        (update path pos span actual)
        (printf "Updated expectation in ~a\n" path)]
-      [(string=? actual expected)
-       (check-equal? actual expected)]
+      [equal?
+       (check-true equal?)]
       [else
        (displayln "Diff:" (current-error-port))
        (displayln (pretty-diff expected actual) (current-error-port))
-       (check-equal? actual expected)])))
+       (check-true equal?)])))
 
 (define (run-expect-exn thunk expected path pos span
-                        [update update-file])
+                        [update update-file]
+                        #:strict [strict? #f])
   (define name (if path
                    (format "~a:~a" path pos)
                    "expect-exn"))
@@ -135,47 +162,54 @@
     (with-handlers ([exn:fail?
                      (lambda (e)
                        (define actual (exn-message e))
+                       (define equal?
+                         (if strict?
+                             (string=? actual expected)
+                             (string=? (normalize-string actual)
+                                       (normalize-string expected))))
                        (cond
-                         [(and path (update-mode? name) (not (string=? actual expected)))
+                         [(and path (update-mode? name) (not equal?))
                           (update path pos span actual)
                           (printf "Updated expectation in ~a\n" path)]
-                         [(string=? actual expected)
-                          (check-equal? actual expected)]
+                         [equal?
+                          (check-true equal?)]
                          [else
                           (displayln "Diff:" (current-error-port))
                           (displayln (pretty-diff expected actual) (current-error-port))
-                          (check-equal? actual expected)]))])
+                          (check-true equal?)]))])
       (begin
         (thunk)
         (fail "expected an exception")))))
 
 (define-syntax (expect stx)
   (syntax-parse stx
-    [(_ expr expected:str)
-      (define src (syntax-source #'expected))
-      (define pos (or (syntax-position #'expected) 0))
-      (define span (or (syntax-span #'expected)
-                       (string-length (syntax-e #'expected))))
-      #`(run-expect (lambda () expr)
-                    expected
-                    #,(and src (path->string src))
-                    #,pos
-                    #,span)]))
+    [(_ expr expected:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
+     (define src (syntax-source #'expected))
+     (define pos (or (syntax-position #'expected) 0))
+     (define span (or (syntax-span #'expected)
+                      (string-length (syntax-e #'expected))))
+     #`(run-expect (lambda () expr)
+                   expected
+                   #,(and src (path->string src))
+                   #,pos
+                   #,span
+                   #:strict s?)]))
 
 (define-syntax (expect-file stx)
   (syntax-parse stx
-    [(_ expr path:str)
+    [(_ expr path:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      #'(let ([p path])
          (run-expect (lambda () expr)
                      (call-with-input-file p port->string)
                      (path->string p)
                      0
                      0
-                     update-file-entire))]))
+                     update-file-entire
+                     #:strict s?))]))
 
 (define-syntax (expect-exn stx)
   (syntax-parse stx
-    [(_ expr expected:str)
+    [(_ expr expected:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      (define src (syntax-source #'expected))
      (define pos (or (syntax-position #'expected) 0))
      (define span (or (syntax-span #'expected)
@@ -184,5 +218,6 @@
                        expected
                        #,(and src (path->string src))
                        #,pos
-                       #,span)]))
+                       #,span
+                       #:strict s?)]))
 

--- a/tests/expect.rkt
+++ b/tests/expect.rkt
@@ -7,11 +7,15 @@
   (test-suite
    "expect-tests"
    (expect (display "hello") "hello")
-   (expect (begin
-             (displayln "hello")
-             (displayln (+ 1 2)))
-           "hello\n3\n")
-   (expect (void) "")))
+  (expect (begin
+            (displayln "hello")
+            (displayln (+ 1 2)))
+          "hello\n3\n")
+  (expect (void) "")
+  ;; Flexible whitespace matching
+  (expect (display "hello") "  hello  \n")
+  ;; Strict matching
+  (expect (display "strict") "strict" #:strict? #t)))
 
 (module+ test
   (run-tests expect-tests))


### PR DESCRIPTION
## Summary
- support relaxed whitespace checks in `expect`, `expect-file`, and `expect-exn`
- provide `#:strict?` keyword to force exact matching
- update tests for the new behaviour

## Testing
- `raco test -x tests/expect.rkt`
- `raco test -x .`

------
https://chatgpt.com/codex/tasks/task_e_6846c50a8e40832884a165d75358fd12