### PR TITLE
Allow multiple strings in expect forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Additional forms mirror features from the OCaml and Rust libraries:
   and rewrites that file when updating.
 * `expect-exn` checks that an expression raises an exception with a given
   message.
+* All expectation forms accept multiple string arguments which are
+  concatenated together. This is handy when using
+  `#lang at-exp` for multi-line expectations.
 * Setting the `RECSPECS_UPDATE_TEST` environment variable to a test case
   name limits updates to only that expectation.
 
@@ -30,6 +33,18 @@ Additional forms mirror features from the OCaml and Rust libraries:
     (displayln "hello")
     (displayln (+ 1 2)))
   "hello\n3\n")
+```
+
+Using @ expressions from `#lang at-exp` can make multi-line output
+easier to write:
+
+```racket
+#lang at-exp racket
+(require recspecs)
+
+@expect[(begin (displayln "hello") (displayln (+ 1 2)))]{
+hello
+3}
 ```
 
 Run the file with `raco test` (or any RackUnit runner) to execute the

--- a/info.rkt
+++ b/info.rkt
@@ -15,4 +15,5 @@
 (define build-deps
   (list "racket-doc"
         "rackunit-lib"
-        "scribble-lib"))
+        "scribble-lib"
+        "scribble-doc"))

--- a/main.rkt
+++ b/main.rkt
@@ -183,13 +183,19 @@
 
 (define-syntax (expect stx)
   (syntax-parse stx
-    [(_ expr expected:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
-     (define src (syntax-source #'expected))
-     (define pos (or (syntax-position #'expected) 0))
-     (define span (or (syntax-span #'expected)
-                      (string-length (syntax-e #'expected))))
+    [(_ expr expected:str ...
+        (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
+     (define expect-list (syntax->list #'(expected ...)))
+     (define first (car expect-list))
+     (define last (car (reverse expect-list)))
+     (define src (syntax-source first))
+     (define pos (or (syntax-position first) 0))
+     (define span (- (+ (or (syntax-position last) 0)
+                        (or (syntax-span last)
+                            (string-length (syntax-e last))))
+                     pos))
      #`(run-expect (lambda () expr)
-                   expected
+                   (string-append #,@expect-list)
                    #,(and src (path->string src))
                    #,pos
                    #,span
@@ -209,13 +215,19 @@
 
 (define-syntax (expect-exn stx)
   (syntax-parse stx
-    [(_ expr expected:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
-     (define src (syntax-source #'expected))
-     (define pos (or (syntax-position #'expected) 0))
-     (define span (or (syntax-span #'expected)
-                      (string-length (syntax-e #'expected))))
-     #'(run-expect-exn (lambda () expr)
-                       expected
+    [(_ expr expected:str ...
+        (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
+     (define expect-list (syntax->list #'(expected ...)))
+     (define first (car expect-list))
+     (define last (car (reverse expect-list)))
+     (define src (syntax-source first))
+     (define pos (or (syntax-position first) 0))
+     (define span (- (+ (or (syntax-position last) 0)
+                        (or (syntax-span last)
+                            (string-length (syntax-e last))))
+                     pos))
+     #`(run-expect-exn (lambda () expr)
+                       (string-append #,@expect-list)
                        #,(and src (path->string src))
                        #,pos
                        #,span

--- a/main.scrbl
+++ b/main.scrbl
@@ -19,25 +19,36 @@ provides @racketfont{recspecs-update-at-point}, which runs the current
 file under @exec{racket-test} with those environment variables set for
 the expectation at the cursor position.
 
-@defform[(expect expr expected-str)]{
+@defform[(expect expr expected-str ...)]{
 Evaluates @racket[expr] and checks that the captured output is equal to
-@racket[expected-str]. If they differ and @tt{RECSPECS_UPDATE} is set,
-the expectation string in the source file is replaced with the new
-value.  Otherwise the test case fails.
+the concatenation of @racket[expected-str]s. If they differ and
+@tt{RECSPECS_UPDATE} is set, the expectation string in the source file
+is replaced with the new value.  Otherwise the test case fails.
 }
 
 @racketblock[
   (require recspecs)
   (expect (displayln "hello") "hello\n")]
 
+It can be convenient to use @racketmodname[at-exp] for multi-line
+expectations:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  @expect[(begin (displayln "hello") (displayln (+ 1 2)))]{
+  hello
+  3}]
+
 @defform[(expect-file expr path-str)]{
 Reads the expectation from @racket[path-str] instead of embedding it in the
 source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.
 }
 
-@defform[(expect-exn expr expected-str)]{
-Checks that @racket[expr] raises an exception whose message matches
-@racket[expected-str]. The message is updated when update mode is enabled.
+@defform[(expect-exn expr expected-str ...)]{
+Checks that @racket[expr] raises an exception whose message matches the
+concatenation of @racket[expected-str]s. The message is updated when
+update mode is enabled.
 }
 
 

--- a/tests/expect.rkt
+++ b/tests/expect.rkt
@@ -10,12 +10,13 @@
   (expect (begin
             (displayln "hello")
             (displayln (+ 1 2)))
-          "hello\n3\n")
+          "hello\n" "3\n")
   (expect (void) "")
   ;; Flexible whitespace matching
   (expect (display "hello") "  hello  \n")
   ;; Strict matching
-  (expect (display "strict") "strict" #:strict? #t)))
+  (expect (display "strict") "strict" #:strict? #t)
+  (expect-exn (raise (exn:fail "oops" (current-continuation-marks))) "oops")))
 
 (module+ test
   (run-tests expect-tests))


### PR DESCRIPTION
## Summary
- allow `expect` and `expect-exn` to accept multiple strings
- document `#lang at-exp` usage and update docs for new arguments
- document multiple-string support in README
- add multi-string tests
- include `scribble-doc` as a build dependency

## Testing
- `raco setup --check-pkg-deps --unused-pkg-deps recspecs`
- `raco test -x -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_68470cb732288328b54cada08bea9886