### PR TITLE
Fix empty expectation bug

### DIFF
--- a/tests/expect.rkt
+++ b/tests/expect.rkt
@@ -12,11 +12,24 @@
             (displayln (+ 1 2)))
           "hello\n" "3\n")
   (expect (void) "")
+  ;; Empty expectation string via implicit "" argument
+  (expect (void))
   ;; Flexible whitespace matching
   (expect (display "hello") "  hello  \n")
   ;; Strict matching
   (expect (display "strict") "strict" #:strict? #t)
   (expect-exn (raise (exn:fail "oops" (current-continuation-marks))) "oops")))
 
+;; Macro expansion with no expectation should not error
+(define expansion-tests
+  (test-suite
+   "expansion-tests"
+   (test-case "expect without string doesn't error"
+     (check-not-exn
+      (lambda ()
+        (parameterize ([current-namespace (make-base-namespace)])
+          (namespace-require 'recspecs)
+          (expand #'(expect (display 5)))))))))
+
 (module+ test
-  (run-tests expect-tests))
+  (run-tests (test-suite "all" expect-tests expansion-tests)))


### PR DESCRIPTION
## Summary
- allow `expect` and `expect-exn` to be used with no expected strings
- test expansion with empty expectations

## Testing
- `../racket/bin/raco test -x tests/expect.rkt`

------
https://chatgpt.com/codex/tasks/task_e_6847313b04a08328bc2b2cb8961315e8