### PR TITLE
Switch to check for rackunit tests

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -136,21 +136,23 @@
                    "expect"))
   (test-case name
     (define actual (with-output-to-string thunk))
-    (define equal?
+    (define comparator
       (if strict?
-          (string=? actual expected)
-          (string=? (normalize-string actual)
-                    (normalize-string expected))))
+          string=?
+          (lambda (e a)
+            (string=? (normalize-string a)
+                      (normalize-string e)))))
+    (define equal? (comparator expected actual))
     (cond
       [(and path (update-mode? name) (not equal?))
        (update path pos span actual)
        (printf "Updated expectation in ~a\n" path)]
       [equal?
-       (check-true equal?)]
+       (check comparator expected actual)]
       [else
        (displayln "Diff:" (current-error-port))
        (displayln (pretty-diff expected actual) (current-error-port))
-       (check-true equal?)])))
+       (check comparator expected actual)])))
 
 (define (run-expect-exn thunk expected path pos span
                         [update update-file]
@@ -162,21 +164,23 @@
     (with-handlers ([exn:fail?
                      (lambda (e)
                        (define actual (exn-message e))
-                       (define equal?
+                       (define comparator
                          (if strict?
-                             (string=? actual expected)
-                             (string=? (normalize-string actual)
-                                       (normalize-string expected))))
+                             string=?
+                             (lambda (e a)
+                               (string=? (normalize-string a)
+                                         (normalize-string e)))))
+                       (define equal? (comparator expected actual))
                        (cond
                          [(and path (update-mode? name) (not equal?))
                           (update path pos span actual)
                           (printf "Updated expectation in ~a\n" path)]
                          [equal?
-                          (check-true equal?)]
+                          (check comparator expected actual)]
                          [else
                           (displayln "Diff:" (current-error-port))
                           (displayln (pretty-diff expected actual) (current-error-port))
-                          (check-true equal?)]))])
+                          (check comparator expected actual)]))])
       (begin
         (thunk)
         (fail "expected an exception")))))


### PR DESCRIPTION
## Summary
- replace `check-true` usage with `check` comparing expected and actual values
- define a single `comparator` and reuse it in each expectation function

## Testing
- `../racket/bin/raco test tests/expect.rkt`


------
https://chatgpt.com/codex/tasks/task_e_68473098d5d083288bc25632f2afe105