### PR TITLE
Fix expect search regex for Emacs helper

### DIFF
--- a/emacs/recspecs.el
+++ b/emacs/recspecs.el
@@ -17,9 +17,21 @@
 Searches backward for an `expect` form and returns the position of its
 expectation string.  Signal an error if none is found."
   (save-excursion
-    (unless (re-search-backward "(expect\(-exn\)?\|expect-file" nil t)
+    (unless (re-search-backward
+             (rx (or (seq "("
+                         (or "expect" "expect-exn" "expect-file")
+                         symbol-end)
+                     (seq "@" (? "(")
+                         (or "expect" "expect-exn" "expect-file")
+                         symbol-end)))
+             nil t)
       (error "No expect form found"))
-    (forward-char 1) ;; skip the opening paren
+    (when (looking-at "@")
+      (forward-char 1)
+      (when (looking-at "(")
+        (forward-char 1)))
+    (when (looking-at "(")
+      (forward-char 1)) ;; skip opening paren if present
     (forward-symbol 1) ;; skip expect / expect-exn / expect-file
     (skip-chars-forward "\s-")
     (forward-sexp 1) ;; expression or path


### PR DESCRIPTION
## Summary
- fix expect search in `recspecs--expect-pos`
- handle `@expect` forms in Emacs helper

## Testing
- `raco test tests/expect.rkt` *(fails: `raco: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684731b1bf948328ab6b10d67a6d2c30