### PR TITLE
Fix expectation offset bug

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -52,8 +52,9 @@
   ;; Replace the expectation string located at [pos, pos+span) in the file
   ;; at `path` with the printed representation of `new-str`.
   (define bs (file->bytes path))
-  (define before (subbytes bs 0 pos))
-  (define after (subbytes bs (+ pos span)))
+  (define start (sub1 pos))
+  (define before (subbytes bs 0 start))
+  (define after (subbytes bs (+ start span)))
   (define new-bs (bytes-append before
                                (string->bytes/utf-8 (format "~s" new-str))
                                after))


### PR DESCRIPTION
## Summary
- fix offset when replacing expectation strings

## Testing
- `../racket/bin/raco test tests/expect.rkt`

------
https://chatgpt.com/codex/tasks/task_e_6847466aa2e883288761b9500f2f4060