### PR TITLE
Support updating empty @expect

### DIFF
--- a/tests/expect.rkt
+++ b/tests/expect.rkt
@@ -31,5 +31,25 @@
           (namespace-require 'recspecs)
           (expand #'(expect (display 5)))))))))
 
+;; Ensure that @expect with empty braces is updated
+(define at-exp-empty-tests
+  (test-suite
+   "at-exp-empty-tests"
+   (test-case "updates empty at-exp braces"
+     (define tmp (make-temporary-file "tmp~a.rkt"))
+     (define main-path (build-path (current-directory) ".." "main.rkt"))
+     (call-with-output-file tmp
+       #:exists 'truncate/replace
+       (lambda (out)
+         (fprintf out "#lang at-exp racket\n(require (file \"~a\"))\n@expect[(displayln \"foo\")]{}\n" (path->string main-path))))
+     (putenv "RECSPECS_UPDATE" "1")
+     (dynamic-require tmp #f)
+     (putenv "RECSPECS_UPDATE" "")
+      (define expected
+        (string-append "#lang at-exp racket\n"
+                       "(require (file \"" (path->string main-path) "\"))\n"
+                       "@expect[(displayln \"foo\")]{" "foo\n" "}\n"))
+     (check-equal? (file->string tmp) expected))))
+
 (module+ test
-  (run-tests (test-suite "all" expect-tests expansion-tests)))
+  (run-tests (test-suite "all" expect-tests expansion-tests at-exp-empty-tests)))


### PR DESCRIPTION
## Summary
- add `update-file-empty` to handle empty brace updates
- detect empty at-exp blocks in `expect` and `expect-exn`
- test updating an empty `@expect` block

## Testing
- `raco test tests/expect.rkt`

------
https://chatgpt.com/codex/tasks/task_e_68474c2af45083289481a5f7e2f14784