### PR TITLE
Add verbose output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Additional forms mirror features from the OCaml and Rust libraries:
   `#lang at-exp` for multi-line expectations.
 * Setting the `RECSPECS_UPDATE_TEST` environment variable to a test case
   name limits updates to only that expectation.
+* Set `RECSPECS_VERBOSE` or parameterize `recspecs-verbose?` to print
+  captured output while tests run.
 
 ## Example
 
@@ -59,6 +61,12 @@ shown for that test case:
 
 ```console
 $ RECSPECS_UPDATE=1 RECSPECS_UPDATE_TEST=my-test.rkt:42 raco test my-test.rkt
+```
+
+Enable verbose output with:
+
+```console
+$ RECSPECS_VERBOSE=1 raco test my-test.rkt
 ```
 
 ### Emacs integration

--- a/main.rkt
+++ b/main.rkt
@@ -15,7 +15,13 @@
 
 (provide expect
          expect-file
-         expect-exn)
+         expect-exn
+         recspecs-verbose?)
+
+;; When enabled, expectation output is printed to the actual output
+;; port as it is produced. The parameter defaults to #t when the
+;; `RECSPECS_VERBOSE` environment variable is set.
+(define recspecs-verbose? (make-parameter (and (getenv "RECSPECS_VERBOSE") #t)))
 
 ;; Normalize a string by trimming leading and trailing whitespace and removing
 ;; common indentation from all lines. This is used when comparing expectation
@@ -23,14 +29,12 @@
 (define (normalize-string s)
   (define trimmed (string-trim s))
   (define lines (regexp-split #px"\r?\n" trimmed))
-  (define non-empty-lines
-    (filter (lambda (l) (regexp-match? #px"\\S" l)) lines))
+  (define non-empty-lines (filter (lambda (l) (regexp-match? #px"\\S" l)) lines))
   (define min-indent
     (if (null? non-empty-lines)
         0
         (apply min
-               (map (lambda (l)
-                      (string-length (car (regexp-match #px"^[ \t]*" l))))
+               (map (lambda (l) (string-length (car (regexp-match #px"^[ \t]*" l))))
                     non-empty-lines))))
   (define dedented
     (for/list ([l lines])
@@ -76,13 +80,8 @@
     (if quoting?
         (format "~s" new-str)
         new-str))
-  (define new-bs (bytes-append before
-                               (string->bytes/utf-8 replacement)
-                               after))
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (write-bytes new-bs out))))
+  (define new-bs (bytes-append before (string->bytes/utf-8 replacement) after))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-bytes new-bs out))))
 
 ;; Replace empty braces at [pos, pos+span) with `{new-str}`
 (define (update-file-empty path pos span new-str)
@@ -91,22 +90,13 @@
   (define before (subbytes bs 0 start))
   (define snippet (bytes->string/utf-8 (subbytes bs start (+ start span))))
   (define after (subbytes bs (+ start span)))
-  (define replaced
-    (regexp-replace #px"\\{\\s*\\}\\s*$" snippet (format "{~a}" new-str)))
-  (define new-bs (bytes-append before
-                               (string->bytes/utf-8 replaced)
-                               after))
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (write-bytes new-bs out))))
+  (define replaced (regexp-replace #px"\\{\\s*\\}\\s*$" snippet (format "{~a}" new-str)))
+  (define new-bs (bytes-append before (string->bytes/utf-8 replaced) after))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-bytes new-bs out))))
 
 ;; Replace the entire file at `path` with `new-str`.
 (define (update-file-entire path _pos _span new-str)
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (display new-str out))))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (display new-str out))))
 
 ;; Split a string into lines without dropping trailing empty lines
 (define (string->lines s)
@@ -126,17 +116,18 @@
   ;; fill table
   (for ([i (in-range m)])
     (for ([j (in-range n)])
-      (vector-set! (vector-ref tbl (add1 i)) (add1 j)
+      (vector-set! (vector-ref tbl (add1 i))
+                   (add1 j)
                    (if (string=? (list-ref a-lines i) (list-ref b-lines j))
                        (add1 (vector-ref (vector-ref tbl i) j))
                        (max (vector-ref (vector-ref tbl i) (add1 j))
                             (vector-ref (vector-ref tbl (add1 i)) j))))))
   ;; backtrack
   (define diffs '())
-  (let loop ([i m] [j n])
+  (let loop ([i m]
+             [j n])
     (cond
-      [(and (> i 0) (> j 0)
-             (string=? (list-ref a-lines (sub1 i)) (list-ref b-lines (sub1 j))))
+      [(and (> i 0) (> j 0) (string=? (list-ref a-lines (sub1 i)) (list-ref b-lines (sub1 j))))
        (set! diffs (cons (cons 'same (list-ref a-lines (sub1 i))) diffs))
        (loop (sub1 i) (sub1 j))]
       [(and (> j 0)
@@ -152,102 +143,99 @@
 
 ;; Render a diff as a string with ANSI color codes
 (define (pretty-diff expected actual #:color? [color? #t])
-  (define diffs (lines-diff (string->lines expected)
-                            (string->lines actual)))
+  (define diffs (lines-diff (string->lines expected) (string->lines actual)))
   (define (color c s)
     (if color?
         (string-append "\x1b[" c "m" s "\x1b[0m")
         s))
-  (string-join
-   (for/list ([d diffs])
-     (match d
-       [(cons 'same l) (string-append "  " l)]
-       [(cons 'add l) (color "32" (string-append "+ " l))]
-       [(cons 'del l) (color "31" (string-append "- " l))]))
-   "\n"))
+  (string-join (for/list ([d diffs])
+                 (match d
+                   [(cons 'same l) (string-append "  " l)]
+                   [(cons 'add l) (color "32" (string-append "+ " l))]
+                   [(cons 'del l) (color "31" (string-append "- " l))]))
+               "\n"))
 
-(define (run-expect thunk expected path pos span
-                    [update update-file]
-                    #:strict [strict? #f])
+(define (run-expect thunk expected path pos span [update update-file] #:strict [strict? #f])
   ;; Returns a rackunit test that evaluates `thunk`, captures anything printed
   ;; to the current output port and compares it to `expected`. When update mode
   ;; is enabled and the values differ, the source file is rewritten instead of
   ;; failing the test.
-  (define name (if path
-                   (format "~a:~a" path pos)
-                   "expect"))
+  (define name
+    (if path
+        (format "~a:~a" path pos)
+        "expect"))
   (test-case name
-    (define actual (with-output-to-string thunk))
+    (define out-str (open-output-string))
+    (define base (current-output-port))
+    (define actual
+      (parameterize ([current-output-port (if (recspecs-verbose?)
+                                              (combine-output base out-str)
+                                              out-str)])
+        (thunk)
+        (get-output-string out-str)))
     (define comparator
       (if strict?
           string=?
-          (lambda (e a)
-            (string=? (normalize-string a)
-                      (normalize-string e)))))
+          (lambda (e a) (string=? (normalize-string a) (normalize-string e)))))
     (define equal? (comparator expected actual))
     (cond
       [(and path (update-mode? name) (not equal?))
        (update path pos span actual)
        (printf "Updated expectation in ~a\n" path)]
-      [equal?
-       (check comparator expected actual)]
+      [equal? (check comparator expected actual)]
       [else
-       (define color? (and (terminal-port? (current-error-port))
-                           (not (getenv "NO_COLOR"))) )
+       (define color? (and (terminal-port? (current-error-port)) (not (getenv "NO_COLOR"))))
        (displayln "Diff:" (current-error-port))
-       (displayln (pretty-diff expected actual #:color? color?)
-                  (current-error-port))
+       (displayln (pretty-diff expected actual #:color? color?) (current-error-port))
        (check comparator expected actual)])))
 
-(define (run-expect-exn thunk expected path pos span
-                        [update update-file]
-                        #:strict [strict? #f])
-  (define name (if path
-                   (format "~a:~a" path pos)
-                   "expect-exn"))
+(define (run-expect-exn thunk expected path pos span [update update-file] #:strict [strict? #f])
+  (define name
+    (if path
+        (format "~a:~a" path pos)
+        "expect-exn"))
   (test-case name
-    (with-handlers ([exn:fail?
-                     (lambda (e)
-                       (define actual (exn-message e))
-                       (define comparator
-                         (if strict?
-                             string=?
-                             (lambda (e a)
-                               (string=? (normalize-string a)
-                                         (normalize-string e)))))
-                       (define equal? (comparator expected actual))
-                       (cond
-                         [(and path (update-mode? name) (not equal?))
-                          (update path pos span actual)
-                          (printf "Updated expectation in ~a\n" path)]
-                         [equal?
-                          (check comparator expected actual)]
-                         [else
-                          (define color? (and (terminal-port? (current-error-port))
-                                              (not (getenv "NO_COLOR"))) )
-                          (displayln "Diff:" (current-error-port))
-                          (displayln (pretty-diff expected actual #:color? color?)
-                                     (current-error-port))
-                          (check comparator expected actual)]))])
+    (with-handlers
+        ([exn:fail?
+          (lambda (e)
+            (define actual (exn-message e))
+            (define comparator
+              (if strict?
+                  string=?
+                  (lambda (e a) (string=? (normalize-string a) (normalize-string e)))))
+            (define equal? (comparator expected actual))
+            (cond
+              [(and path (update-mode? name) (not equal?))
+               (update path pos span actual)
+               (printf "Updated expectation in ~a\n" path)]
+              [equal? (check comparator expected actual)]
+              [else
+               (define color? (and (terminal-port? (current-error-port)) (not (getenv "NO_COLOR"))))
+               (displayln "Diff:" (current-error-port))
+               (displayln (pretty-diff expected actual #:color? color?) (current-error-port))
+               (check comparator expected actual)]))])
       (begin
         (thunk)
         (fail "expected an exception")))))
 
 (define-syntax (expect stx)
   (syntax-parse stx
-    [(_ expr expected-first:str expected-rest:str ...
+    [(_ expr
+        expected-first:str
+        expected-rest:str ...
         (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      (define expect-list (syntax->list #'(expected-first expected-rest ...)))
      (define first #'expected-first)
-     (define last-syn (if (null? (syntax->list #'(expected-rest ...)))
-                         #'expected-first
-                         (last expect-list)))
+     (define last-syn
+       (if (null? (syntax->list #'(expected-rest ...)))
+           #'expected-first
+           (last expect-list)))
      (define src (syntax-source first))
      (define pos (or (syntax-position first) 0))
-     (define span (- (+ (or (syntax-position last-syn) 0)
-                        (or (syntax-span last-syn)
-                            (string-length (syntax-e last-syn))))
-                     pos))
+     (define span
+       (- (+ (or (syntax-position last-syn) 0)
+             (or (syntax-span last-syn) (string-length (syntax-e last-syn))))
+          pos))
      #`(run-expect (lambda () expr)
                    (string-append #,@expect-list)
                    #,(and src (path->string src))
@@ -258,22 +246,25 @@
      (define src (syntax-source stx))
      (define pos (syntax-position stx))
      (define span (syntax-span stx))
-     (define snippet
-       (and src pos span
-            (substring (file->string src)
-                      (sub1 pos)
-                      (+ (sub1 pos) span))))
-     (define has-empty?
-       (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
+     (define snippet (and src pos span (substring (file->string src) (sub1 pos) (+ (sub1 pos) span))))
+     (define has-empty? (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
      (if has-empty?
-         #`(run-expect (lambda () expr) "" #,(path->string src) #,pos #,span update-file-empty #:strict s?)
+         #`(run-expect (lambda () expr)
+                       ""
+                       #,(path->string src)
+                       #,pos
+                       #,span
+                       update-file-empty
+                       #:strict s?)
          #'(run-expect (lambda () expr) "" #f 0 0 #:strict s?))]))
 
 (define-syntax (expect-file stx)
   (syntax-parse stx
     [(_ expr path:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      #'(let* ([p path]
-              [p (if (path? p) p (string->path p))])
+              [p (if (path? p)
+                     p
+                     (string->path p))])
          (run-expect (lambda () expr)
                      (call-with-input-file p port->string)
                      (path->string p)
@@ -284,19 +275,22 @@
 
 (define-syntax (expect-exn stx)
   (syntax-parse stx
-    [(_ expr expected-first:str expected-rest:str ...
+    [(_ expr
+        expected-first:str
+        expected-rest:str ...
         (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      (define expect-list (syntax->list #'(expected-first expected-rest ...)))
      (define first #'expected-first)
-     (define last-syn (if (null? (syntax->list #'(expected-rest ...)))
-                         #'expected-first
-                         (last expect-list)))
-    (define src (syntax-source first))
-    (define pos (or (syntax-position first) 0))
-    (define span (- (+ (or (syntax-position last-syn) 0)
-                        (or (syntax-span last-syn)
-                            (string-length (syntax-e last-syn))))
-                     pos))
+     (define last-syn
+       (if (null? (syntax->list #'(expected-rest ...)))
+           #'expected-first
+           (last expect-list)))
+     (define src (syntax-source first))
+     (define pos (or (syntax-position first) 0))
+     (define span
+       (- (+ (or (syntax-position last-syn) 0)
+             (or (syntax-span last-syn) (string-length (syntax-e last-syn))))
+          pos))
      #`(run-expect-exn (lambda () expr)
                        (string-append #,@expect-list)
                        #,(and src (path->string src))
@@ -307,14 +301,14 @@
      (define src (syntax-source stx))
      (define pos (syntax-position stx))
      (define span (syntax-span stx))
-     (define snippet
-       (and src pos span
-            (substring (file->string src)
-                      (sub1 pos)
-                      (+ (sub1 pos) span))))
-     (define has-empty?
-       (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
+     (define snippet (and src pos span (substring (file->string src) (sub1 pos) (+ (sub1 pos) span))))
+     (define has-empty? (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
      (if has-empty?
-         #`(run-expect-exn (lambda () expr) "" #,(path->string src) #,pos #,span update-file-empty #:strict s?)
+         #`(run-expect-exn (lambda () expr)
+                           ""
+                           #,(path->string src)
+                           #,pos
+                           #,span
+                           update-file-empty
+                           #:strict s?)
          #'(run-expect-exn (lambda () expr) "" #f 0 0 #:strict s?))]))
-

--- a/main.scrbl
+++ b/main.scrbl
@@ -14,6 +14,13 @@ diff is printed to help understand the mismatch. Updating can be
 restricted to a single test case by setting
 @tt{RECSPECS_UPDATE_TEST} to the name shown for that case.
 
+Verbose mode can be enabled by setting @tt{RECSPECS_VERBOSE} or by
+parameterizing @racket[recspecs-verbose?]. When enabled, captured
+output is echoed to the real output port as it is produced.
+For example:
+
+@verbatim|{RECSPECS_VERBOSE=1 raco test my-test.rkt}|
+
 For Emacs users, the accompanying @filepath{emacs/recspecs.el} file
 provides @racketfont{recspecs-update-at-point}, which runs the current
 file under @exec{racket-test} with those environment variables set for

--- a/tests/verbose.rkt
+++ b/tests/verbose.rkt
@@ -1,0 +1,32 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define recorded '())
+
+(define (make-record-port)
+  (make-output-port 'record
+                    always-evt
+                    (lambda (bs start end non-block? break?)
+                      (set! recorded
+                            (append recorded (list (bytes->string/utf-8 (subbytes bs start end)))))
+                      (- end start))
+                    (lambda () (void))))
+
+(define verbose-tests
+  (test-suite "verbose-tests"
+    (test-case "echoes output"
+      (set! recorded '())
+      (define port (make-record-port))
+      (parameterize ([recspecs-verbose? #t]
+                     [current-output-port port])
+        (run-tests (test-suite "sub"
+                     (expect (begin
+                               (display "a")
+                               (display "b"))
+                             "ab"))))
+      (check-equal? (take recorded 2) '("a" "b")))))
+
+(module+ test
+  (run-tests verbose-tests))


### PR DESCRIPTION
## Summary
- add `recspecs-verbose?` parameter controlled by `RECSPECS_VERBOSE`
- print output as it's produced when verbose mode is enabled
- document verbose mode and show how to enable it
- test that verbose mode forwards output immediately

## Testing
- `raco make main.rkt main.scrbl tests/verbose.rkt`
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684afb6a46f88328836f04c48506a269