### PR TITLE
Add output filtering parameter

### DIFF
--- a/main.scrbl
+++ b/main.scrbl
@@ -51,4 +51,16 @@ concatenation of @racket[expected-str]s. The message is updated when
 update mode is enabled.
 }
 
+@defparam[recspecs-output-filter filter (-> string? string?)]{
+A parameter whose value is applied to captured output and exception
+messages before they are compared against expectations.  Use this to
+strip nondeterministic data.
+
+@racketblock[
+  (parameterize ([recspecs-output-filter
+                  (lambda (s)
+                    (regexp-replace #px"timestamp: \\d+" s "timestamp: <ts>"))])
+    (expect (displayln "timestamp: 123") "timestamp: <ts>\n"))]
+}
+
 

--- a/tests/filter.rkt
+++ b/tests/filter.rkt
@@ -1,0 +1,14 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define filter-tests
+  (test-suite "filter-tests"
+    (test-case "output-filter"
+      (parameterize ([recspecs-output-filter
+                      (lambda (s) (regexp-replace #px"timestamp: \\d+" s "timestamp: <ts>"))])
+        (expect (displayln "timestamp: 123") "timestamp: <ts>\n")))))
+
+(module+ test
+  (run-tests filter-tests))


### PR DESCRIPTION
## Summary
- support filtering captured output via new `recspecs-output-filter` parameter
- document output filtering with an example
- add regression tests for the filter

## Testing
- `raco make main.rkt tests/filter.rkt main.scrbl`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_684afb69212c83288ec94b3708f3da0a