### PR TITLE
Add recspecs-output-filter parameter

### DIFF
--- a/main.scrbl
+++ b/main.scrbl
@@ -26,6 +26,16 @@ provides @racketfont{recspecs-update-at-point}, which runs the current
 file under @exec{racket-test} with those environment variables set for
 the expectation at the cursor position.
 
+Output can be transformed before it is compared by parameterizing
+@racket[recspecs-output-filter]. The parameter holds a procedure that
+receives the captured string and returns a new string used for the
+comparison and when updating:
+
+@racketblock[
+  (parameterize ([recspecs-output-filter
+                  (lambda (s) (regexp-replace* #px"[0-9]+" s ""))])
+    (expect (display "v1.2") "v."))]
+
 @defform[(expect expr expected-str ...)]{
 Evaluates @racket[expr] and checks that the captured output is equal to
 the concatenation of @racket[expected-str]s. If they differ and

--- a/tests/output-filter.rkt
+++ b/tests/output-filter.rkt
@@ -1,0 +1,16 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define (strip-digits s)
+  (regexp-replace* #px"[0-9]+" s ""))
+
+(define filter-tests
+  (test-suite "filter-tests"
+    (expect (display "a1b2") "ab")
+    (expect-exn (raise (exn:fail "err1" (current-continuation-marks))) "err")))
+
+(module+ test
+  (parameterize ([recspecs-output-filter strip-digits])
+    (run-tests filter-tests)))


### PR DESCRIPTION
## Summary
- add `recspecs-output-filter` parameter
- filter captured output in `run-expect` and `run-expect-exn`
- document the new parameter
- test applying a filter

## Testing
- `raco make main.rkt`
- `raco make main.scrbl`
- `raco make tests/output-filter.rkt`
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684b04610b508328bdc5b5c7fb4229d7