### PR TITLE
Add expect-unreachable form

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Additional forms mirror features from the OCaml and Rust libraries:
   and rewrites that file when updating.
 * `expect-exn` checks that an expression raises an exception with a given
   message.
+* `expect-unreachable` fails if the wrapped expression is evaluated.
 * All expectation forms accept multiple string arguments which are
   concatenated together. This is handy when using
   `#lang at-exp` for multi-line expectations.
@@ -47,6 +48,13 @@ easier to write:
 @expect[(begin (displayln "hello") (displayln (+ 1 2)))]{
 hello
 3}
+```
+
+Mark code that should not run with `expect-unreachable`:
+
+```racket
+(when #f
+  (expect-unreachable (displayln "never")))
 ```
 
 Run the file with `raco test` (or any RackUnit runner) to execute the

--- a/main.scrbl
+++ b/main.scrbl
@@ -68,4 +68,10 @@ concatenation of @racket[expected-str]s. The message is updated when
 update mode is enabled.
 }
 
+@defform[(expect-unreachable expr)]{
+Fails the enclosing test if @racket[expr] evaluates. When update mode is
+enabled, the form is replaced with @racket[expr] in the source instead of
+failing.
+}
+
 

--- a/tests/unreachable.rkt
+++ b/tests/unreachable.rkt
@@ -1,0 +1,33 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define unreachable-tests
+  (test-suite "unreachable-tests"
+    (test-case "fails when reached"
+      (check-exn exn:fail?
+                 (lambda ()
+                   (parameterize ([current-test-case-around (lambda (th) (th))])
+                     (expect-unreachable (void))))))))
+
+(define update-tests
+  (test-suite "update-tests"
+    (test-case "updates source when reached in update mode"
+      (define tmp (make-temporary-file "unreach~a.rkt"))
+      (call-with-output-file
+       tmp
+       #:exists 'truncate/replace
+       (lambda (out)
+         (fprintf out "#lang racket\n(require recspecs)\n(expect-unreachable (displayln \"x\"))\n")))
+      (putenv "RECSPECS_UPDATE" "1")
+      (dynamic-require tmp #f)
+      (putenv "RECSPECS_UPDATE" "")
+      (define expected "#lang racket\n(require recspecs)\n(displayln \"x\")\n")
+      (check-equal? (file->string tmp) expected)
+      (delete-file tmp))))
+
+(module+ test
+  (run-tests (test-suite "all"
+               unreachable-tests
+               update-tests)))


### PR DESCRIPTION
## Summary
- add `expect-unreachable` form and expose it
- implement source rewriting helper
- document unreachable expectations
- illustrate unreachable expectations in README
- test normal and update modes for `expect-unreachable`

## Testing
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684b07a63fcc8328bc43c5fb4dc06dcb