### PR TITLE
Fix library URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # recspecs
 
 `recspecs` provides a lightweight expect testing facility for Racket. It is
-inspired by [Jane Street's `expect_test` for OCaml](https://github.com/janestreet/expect_test)
-and the [`expect-test` crate](https://github.com/greyblake/expect-test) for Rust.
+inspired by [Jane Street's `expect_test` for OCaml](https://github.com/janestreet/ppx_expect)
+and the [`expect-test` crate](https://github.com/rust-analyzer/expect-test) for Rust.
 
 Expect tests record the output of expressions directly in the source file.
 Each `expect` form expands to a small RackUnit test that compares the


### PR DESCRIPTION
## Summary
- update OCaml library link to `janestreet/ppx_expect`
- update Rust library link to `rust-analyzer/expect-test`


------
https://chatgpt.com/codex/tasks/task_e_684b109ee3448328ae377d1bb186513c