### PR TITLE
Add capture-output helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Additional forms mirror features from the OCaml and Rust libraries:
   `#lang at-exp` for multi-line expectations.
 * Setting the `RECSPECS_UPDATE_TEST` environment variable to a test case
   name limits updates to only that expectation.
+* `capture-output` runs a thunk and returns everything it prints.
 
 ## Example
 
@@ -45,6 +46,13 @@ easier to write:
 @expect[(begin (displayln "hello") (displayln (+ 1 2)))]{
 hello
 3}
+```
+
+The helper `capture-output` runs a thunk and returns everything it prints:
+
+```racket
+(capture-output (lambda () (display "hi")))
+;; => "hi"
 ```
 
 Run the file with `raco test` (or any RackUnit runner) to execute the

--- a/main.rkt
+++ b/main.rkt
@@ -15,7 +15,8 @@
 
 (provide expect
          expect-file
-         expect-exn)
+         expect-exn
+         capture-output)
 
 ;; Normalize a string by trimming leading and trailing whitespace and removing
 ;; common indentation from all lines. This is used when comparing expectation
@@ -23,14 +24,12 @@
 (define (normalize-string s)
   (define trimmed (string-trim s))
   (define lines (regexp-split #px"\r?\n" trimmed))
-  (define non-empty-lines
-    (filter (lambda (l) (regexp-match? #px"\\S" l)) lines))
+  (define non-empty-lines (filter (lambda (l) (regexp-match? #px"\\S" l)) lines))
   (define min-indent
     (if (null? non-empty-lines)
         0
         (apply min
-               (map (lambda (l)
-                      (string-length (car (regexp-match #px"^[ \t]*" l))))
+               (map (lambda (l) (string-length (car (regexp-match #px"^[ \t]*" l))))
                     non-empty-lines))))
   (define dedented
     (for/list ([l lines])
@@ -76,13 +75,8 @@
     (if quoting?
         (format "~s" new-str)
         new-str))
-  (define new-bs (bytes-append before
-                               (string->bytes/utf-8 replacement)
-                               after))
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (write-bytes new-bs out))))
+  (define new-bs (bytes-append before (string->bytes/utf-8 replacement) after))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-bytes new-bs out))))
 
 ;; Replace empty braces at [pos, pos+span) with `{new-str}`
 (define (update-file-empty path pos span new-str)
@@ -91,22 +85,17 @@
   (define before (subbytes bs 0 start))
   (define snippet (bytes->string/utf-8 (subbytes bs start (+ start span))))
   (define after (subbytes bs (+ start span)))
-  (define replaced
-    (regexp-replace #px"\\{\\s*\\}\\s*$" snippet (format "{~a}" new-str)))
-  (define new-bs (bytes-append before
-                               (string->bytes/utf-8 replaced)
-                               after))
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (write-bytes new-bs out))))
+  (define replaced (regexp-replace #px"\\{\\s*\\}\\s*$" snippet (format "{~a}" new-str)))
+  (define new-bs (bytes-append before (string->bytes/utf-8 replaced) after))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (write-bytes new-bs out))))
 
 ;; Replace the entire file at `path` with `new-str`.
 (define (update-file-entire path _pos _span new-str)
-  (call-with-output-file path
-    #:exists 'truncate/replace
-    (lambda (out)
-      (display new-str out))))
+  (call-with-output-file path #:exists 'truncate/replace (lambda (out) (display new-str out))))
+
+;; Run @racket[thunk] and return all text printed to the current output port.
+(define (capture-output thunk)
+  (with-output-to-string thunk))
 
 ;; Split a string into lines without dropping trailing empty lines
 (define (string->lines s)
@@ -126,17 +115,18 @@
   ;; fill table
   (for ([i (in-range m)])
     (for ([j (in-range n)])
-      (vector-set! (vector-ref tbl (add1 i)) (add1 j)
+      (vector-set! (vector-ref tbl (add1 i))
+                   (add1 j)
                    (if (string=? (list-ref a-lines i) (list-ref b-lines j))
                        (add1 (vector-ref (vector-ref tbl i) j))
                        (max (vector-ref (vector-ref tbl i) (add1 j))
                             (vector-ref (vector-ref tbl (add1 i)) j))))))
   ;; backtrack
   (define diffs '())
-  (let loop ([i m] [j n])
+  (let loop ([i m]
+             [j n])
     (cond
-      [(and (> i 0) (> j 0)
-             (string=? (list-ref a-lines (sub1 i)) (list-ref b-lines (sub1 j))))
+      [(and (> i 0) (> j 0) (string=? (list-ref a-lines (sub1 i)) (list-ref b-lines (sub1 j))))
        (set! diffs (cons (cons 'same (list-ref a-lines (sub1 i))) diffs))
        (loop (sub1 i) (sub1 j))]
       [(and (> j 0)
@@ -152,102 +142,92 @@
 
 ;; Render a diff as a string with ANSI color codes
 (define (pretty-diff expected actual #:color? [color? #t])
-  (define diffs (lines-diff (string->lines expected)
-                            (string->lines actual)))
+  (define diffs (lines-diff (string->lines expected) (string->lines actual)))
   (define (color c s)
     (if color?
         (string-append "\x1b[" c "m" s "\x1b[0m")
         s))
-  (string-join
-   (for/list ([d diffs])
-     (match d
-       [(cons 'same l) (string-append "  " l)]
-       [(cons 'add l) (color "32" (string-append "+ " l))]
-       [(cons 'del l) (color "31" (string-append "- " l))]))
-   "\n"))
+  (string-join (for/list ([d diffs])
+                 (match d
+                   [(cons 'same l) (string-append "  " l)]
+                   [(cons 'add l) (color "32" (string-append "+ " l))]
+                   [(cons 'del l) (color "31" (string-append "- " l))]))
+               "\n"))
 
-(define (run-expect thunk expected path pos span
-                    [update update-file]
-                    #:strict [strict? #f])
+(define (run-expect thunk expected path pos span [update update-file] #:strict [strict? #f])
   ;; Returns a rackunit test that evaluates `thunk`, captures anything printed
   ;; to the current output port and compares it to `expected`. When update mode
   ;; is enabled and the values differ, the source file is rewritten instead of
   ;; failing the test.
-  (define name (if path
-                   (format "~a:~a" path pos)
-                   "expect"))
+  (define name
+    (if path
+        (format "~a:~a" path pos)
+        "expect"))
   (test-case name
-    (define actual (with-output-to-string thunk))
+    (define actual (capture-output thunk))
     (define comparator
       (if strict?
           string=?
-          (lambda (e a)
-            (string=? (normalize-string a)
-                      (normalize-string e)))))
+          (lambda (e a) (string=? (normalize-string a) (normalize-string e)))))
     (define equal? (comparator expected actual))
     (cond
       [(and path (update-mode? name) (not equal?))
        (update path pos span actual)
        (printf "Updated expectation in ~a\n" path)]
-      [equal?
-       (check comparator expected actual)]
+      [equal? (check comparator expected actual)]
       [else
-       (define color? (and (terminal-port? (current-error-port))
-                           (not (getenv "NO_COLOR"))) )
+       (define color? (and (terminal-port? (current-error-port)) (not (getenv "NO_COLOR"))))
        (displayln "Diff:" (current-error-port))
-       (displayln (pretty-diff expected actual #:color? color?)
-                  (current-error-port))
+       (displayln (pretty-diff expected actual #:color? color?) (current-error-port))
        (check comparator expected actual)])))
 
-(define (run-expect-exn thunk expected path pos span
-                        [update update-file]
-                        #:strict [strict? #f])
-  (define name (if path
-                   (format "~a:~a" path pos)
-                   "expect-exn"))
+(define (run-expect-exn thunk expected path pos span [update update-file] #:strict [strict? #f])
+  (define name
+    (if path
+        (format "~a:~a" path pos)
+        "expect-exn"))
   (test-case name
-    (with-handlers ([exn:fail?
-                     (lambda (e)
-                       (define actual (exn-message e))
-                       (define comparator
-                         (if strict?
-                             string=?
-                             (lambda (e a)
-                               (string=? (normalize-string a)
-                                         (normalize-string e)))))
-                       (define equal? (comparator expected actual))
-                       (cond
-                         [(and path (update-mode? name) (not equal?))
-                          (update path pos span actual)
-                          (printf "Updated expectation in ~a\n" path)]
-                         [equal?
-                          (check comparator expected actual)]
-                         [else
-                          (define color? (and (terminal-port? (current-error-port))
-                                              (not (getenv "NO_COLOR"))) )
-                          (displayln "Diff:" (current-error-port))
-                          (displayln (pretty-diff expected actual #:color? color?)
-                                     (current-error-port))
-                          (check comparator expected actual)]))])
+    (with-handlers
+        ([exn:fail?
+          (lambda (e)
+            (define actual (exn-message e))
+            (define comparator
+              (if strict?
+                  string=?
+                  (lambda (e a) (string=? (normalize-string a) (normalize-string e)))))
+            (define equal? (comparator expected actual))
+            (cond
+              [(and path (update-mode? name) (not equal?))
+               (update path pos span actual)
+               (printf "Updated expectation in ~a\n" path)]
+              [equal? (check comparator expected actual)]
+              [else
+               (define color? (and (terminal-port? (current-error-port)) (not (getenv "NO_COLOR"))))
+               (displayln "Diff:" (current-error-port))
+               (displayln (pretty-diff expected actual #:color? color?) (current-error-port))
+               (check comparator expected actual)]))])
       (begin
         (thunk)
         (fail "expected an exception")))))
 
 (define-syntax (expect stx)
   (syntax-parse stx
-    [(_ expr expected-first:str expected-rest:str ...
+    [(_ expr
+        expected-first:str
+        expected-rest:str ...
         (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      (define expect-list (syntax->list #'(expected-first expected-rest ...)))
      (define first #'expected-first)
-     (define last-syn (if (null? (syntax->list #'(expected-rest ...)))
-                         #'expected-first
-                         (last expect-list)))
+     (define last-syn
+       (if (null? (syntax->list #'(expected-rest ...)))
+           #'expected-first
+           (last expect-list)))
      (define src (syntax-source first))
      (define pos (or (syntax-position first) 0))
-     (define span (- (+ (or (syntax-position last-syn) 0)
-                        (or (syntax-span last-syn)
-                            (string-length (syntax-e last-syn))))
-                     pos))
+     (define span
+       (- (+ (or (syntax-position last-syn) 0)
+             (or (syntax-span last-syn) (string-length (syntax-e last-syn))))
+          pos))
      #`(run-expect (lambda () expr)
                    (string-append #,@expect-list)
                    #,(and src (path->string src))
@@ -258,22 +238,25 @@
      (define src (syntax-source stx))
      (define pos (syntax-position stx))
      (define span (syntax-span stx))
-     (define snippet
-       (and src pos span
-            (substring (file->string src)
-                      (sub1 pos)
-                      (+ (sub1 pos) span))))
-     (define has-empty?
-       (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
+     (define snippet (and src pos span (substring (file->string src) (sub1 pos) (+ (sub1 pos) span))))
+     (define has-empty? (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
      (if has-empty?
-         #`(run-expect (lambda () expr) "" #,(path->string src) #,pos #,span update-file-empty #:strict s?)
+         #`(run-expect (lambda () expr)
+                       ""
+                       #,(path->string src)
+                       #,pos
+                       #,span
+                       update-file-empty
+                       #:strict s?)
          #'(run-expect (lambda () expr) "" #f 0 0 #:strict s?))]))
 
 (define-syntax (expect-file stx)
   (syntax-parse stx
     [(_ expr path:str (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      #'(let* ([p path]
-              [p (if (path? p) p (string->path p))])
+              [p (if (path? p)
+                     p
+                     (string->path p))])
          (run-expect (lambda () expr)
                      (call-with-input-file p port->string)
                      (path->string p)
@@ -284,19 +267,22 @@
 
 (define-syntax (expect-exn stx)
   (syntax-parse stx
-    [(_ expr expected-first:str expected-rest:str ...
+    [(_ expr
+        expected-first:str
+        expected-rest:str ...
         (~optional (~seq #:strict? s?:expr) #:defaults ([s? #'#f])))
      (define expect-list (syntax->list #'(expected-first expected-rest ...)))
      (define first #'expected-first)
-     (define last-syn (if (null? (syntax->list #'(expected-rest ...)))
-                         #'expected-first
-                         (last expect-list)))
-    (define src (syntax-source first))
-    (define pos (or (syntax-position first) 0))
-    (define span (- (+ (or (syntax-position last-syn) 0)
-                        (or (syntax-span last-syn)
-                            (string-length (syntax-e last-syn))))
-                     pos))
+     (define last-syn
+       (if (null? (syntax->list #'(expected-rest ...)))
+           #'expected-first
+           (last expect-list)))
+     (define src (syntax-source first))
+     (define pos (or (syntax-position first) 0))
+     (define span
+       (- (+ (or (syntax-position last-syn) 0)
+             (or (syntax-span last-syn) (string-length (syntax-e last-syn))))
+          pos))
      #`(run-expect-exn (lambda () expr)
                        (string-append #,@expect-list)
                        #,(and src (path->string src))
@@ -307,14 +293,14 @@
      (define src (syntax-source stx))
      (define pos (syntax-position stx))
      (define span (syntax-span stx))
-     (define snippet
-       (and src pos span
-            (substring (file->string src)
-                      (sub1 pos)
-                      (+ (sub1 pos) span))))
-     (define has-empty?
-       (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
+     (define snippet (and src pos span (substring (file->string src) (sub1 pos) (+ (sub1 pos) span))))
+     (define has-empty? (and snippet (regexp-match? #px"\\{\\s*\\}\\s*$" snippet)))
      (if has-empty?
-         #`(run-expect-exn (lambda () expr) "" #,(path->string src) #,pos #,span update-file-empty #:strict s?)
+         #`(run-expect-exn (lambda () expr)
+                           ""
+                           #,(path->string src)
+                           #,pos
+                           #,span
+                           update-file-empty
+                           #:strict s?)
          #'(run-expect-exn (lambda () expr) "" #f 0 0 #:strict s?))]))
-

--- a/main.scrbl
+++ b/main.scrbl
@@ -51,4 +51,11 @@ concatenation of @racket[expected-str]s. The message is updated when
 update mode is enabled.
 }
 
+@defproc[(capture-output [thunk (-> any/c)]) string?]{
+Runs @racket[thunk] and returns everything it prints to the current output
+port.
+
+@racketblock[(capture-output (lambda () (display "hi")))]
+}
+
 

--- a/tests/capture-output.rkt
+++ b/tests/capture-output.rkt
@@ -1,0 +1,12 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define capture-tests
+  (test-suite "capture-output"
+    (test-case "returns printed text"
+      (check-equal? (capture-output (lambda () (display "hi"))) "hi"))))
+
+(module+ test
+  (run-tests capture-tests))


### PR DESCRIPTION
## Summary
- add `capture-output` helper procedure and provide it
- use the helper within `run-expect`
- document the helper in README and manual
- include example use in both docs
- add a test for `capture-output`

## Testing
- `raco make main.rkt`
- `raco make tests/capture-output.rkt`
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684afb664cbc83289dfd3855bd835515