### PR TITLE
Add capture-output helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Additional forms mirror features from the OCaml and Rust libraries:
   name limits updates to only that expectation.
 * Set `RECSPECS_VERBOSE` or parameterize `recspecs-verbose?` to print
   captured output while tests run.
+* Use `capture-output` to run a thunk and return its printed output.
 
 ## Example
 
@@ -55,6 +56,12 @@ Mark code that should not run with `expect-unreachable`:
 ```racket
 (when #f
   (expect-unreachable (displayln "never")))
+```
+
+You can also capture output directly without an expectation:
+
+```racket
+(capture-output (lambda () (display "hi"))) ; => "hi"
 ```
 
 Run the file with `raco test` (or any RackUnit runner) to execute the

--- a/main.rkt
+++ b/main.rkt
@@ -18,7 +18,8 @@
          expect-exn
          expect-unreachable
          recspecs-verbose?
-         recspecs-output-filter)
+         recspecs-output-filter
+         capture-output)
 
 ;; When enabled, expectation output is printed to the actual output
 ;; port as it is produced. The parameter defaults to #t when the
@@ -28,6 +29,18 @@
 ;; A procedure applied to the captured output before it is compared or
 ;; written back to a file. The parameter defaults to the identity function.
 (define recspecs-output-filter (make-parameter (lambda (s) s)))
+
+;; Run @racket[thunk] and return everything written to the current
+;; output port. When @racket[recspecs-verbose?] is true the output is
+;; also echoed to the original port.
+(define (capture-output thunk)
+  (define out (open-output-string))
+  (define base (current-output-port))
+  (parameterize ([current-output-port (if (recspecs-verbose?)
+                                          (combine-output base out)
+                                          out)])
+    (thunk)
+    (get-output-string out)))
 
 ;; Normalize a string by trimming leading and trailing whitespace and removing
 ;; common indentation from all lines. This is used when comparing expectation

--- a/main.scrbl
+++ b/main.scrbl
@@ -74,4 +74,12 @@ enabled, the form is replaced with @racket[expr] in the source instead of
 failing.
 }
 
+@defproc[(capture-output [thunk (-> any/c)]) string?]{
+Runs @racket[thunk] and returns everything printed to the current output
+port. When @racket[recspecs-verbose?] is true, the output is also echoed
+to the original port.
+
+@racketblock[(capture-output (lambda () (display "hi")))]
+}
+
 

--- a/tests/capture-output.rkt
+++ b/tests/capture-output.rkt
@@ -1,0 +1,12 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define capture-tests
+  (test-suite "capture-output"
+    (test-case "returns output"
+      (check-equal? (capture-output (lambda () (display "hi"))) "hi"))))
+
+(module+ test
+  (run-tests capture-tests))


### PR DESCRIPTION
## Summary
- add `capture-output` function to capture printed output
- document helper in README and manual
- provide basic example for capturing output
- test new helper

## Testing
- `raco make main.rkt main.scrbl tests/capture-output.rkt`
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684b127259808328a7f36103b7d2744f