### PR TITLE
Add expectation helper struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ You can also capture output directly without an expectation:
 (capture-output (lambda () (display "hi"))) ; => "hi"
 ```
 
+The library also exposes a mutable `expectation` value for recording
+output programmatically. Use `with-expectation` to capture output into the
+struct and call `commit-expectation!` or `skip-expectation!` to mark the
+result:
+
+```racket
+(define e (make-expectation))
+(with-expectation e (display "ok"))
+(commit-expectation! e)
+```
+
+`with-expectation` can also wrap other recspecs forms. The recorded output is
+available via @racket[expectation-out]:
+
+```racket
+(define log (make-expectation))
+(with-expectation log
+  (expect (display "hi") "hi"))
+(commit-expectation! log)
+(displayln (expectation-out log)) ; prints ""
+```
+
 Run the file with `raco test` (or any RackUnit runner) to execute the
 expectations. If they fail and you want to update the saved output, set
 `RECSPECS_UPDATE`:

--- a/main.scrbl
+++ b/main.scrbl
@@ -82,4 +82,33 @@ to the original port.
 @racketblock[(capture-output (lambda () (display "hi")))]
 }
 
+@defstruct[expectation ([out string?]
+                        [committed? boolean?]
+                        [skip? boolean?])]{
+Represents recorded output that can be committed or skipped. The
+structure is mutable so repeated @racket[with-expectation] blocks can
+append to @racket[out].}
+
+@defproc[(make-expectation) expectation?]{Create a fresh expectation.}
+
+@defproc[(commit-expectation! [e expectation?]) void?]{Mark @racket[e] as committed.}
+
+@defproc[(reset-expectation! [e expectation?]) void?]{Reset the output and flags of @racket[e].}
+
+@defproc[(skip-expectation! [e expectation?]) void?]{Mark @racket[e] as skipped.}
+
+@defform[(with-expectation e expr ...)]{
+Evaluates the @racket[expr]s and appends anything printed to
+@racket[e]'s @racket[out] field.}
+
+You can wrap any of the expectation forms with @racket[with-expectation] and
+access the captured output with @racket[expectation-out]:
+
+@racketblock[
+  (define log (make-expectation))
+  (with-expectation log
+    (expect (display "hi") "hi"))
+  (commit-expectation! log)
+  (displayln (expectation-out log))]
+
 

--- a/tests/expectation.rkt
+++ b/tests/expectation.rkt
@@ -1,0 +1,50 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define expectation-tests
+  (test-suite "expectation"
+    (test-case "commit recorded output"
+      (define e (make-expectation))
+      (with-expectation e (display "a"))
+      (commit-expectation! e)
+      (check-true (expectation-committed? e))
+      (check-equal? (expectation-out e) "a"))
+    (test-case "skip recorded output"
+      (define e (make-expectation))
+      (with-expectation e (display "b"))
+      (skip-expectation! e)
+      (check-true (expectation-skip? e))
+      (check-equal? (expectation-out e) "b"))
+    (test-case "reset clears state"
+      (define e (make-expectation))
+      (with-expectation e (display "x"))
+      (commit-expectation! e)
+      (reset-expectation! e)
+      (check-equal? (expectation-out e) "")
+      (check-false (expectation-committed? e))
+      (check-false (expectation-skip? e)))
+    (test-case "works with expect"
+      (define e (make-expectation))
+      (with-expectation e (display "hi"))
+      (expect (display (expectation-out e)) "hi"))
+    (test-case "works with expect-file"
+      (define e (make-expectation))
+      (with-expectation e (display "hello\n"))
+      (expect-file (display (expectation-out e)) "data/hello.txt"))
+    (test-case "works with expect-exn"
+      (define e (make-expectation))
+      (with-expectation e (display "boom:"))
+      (expect-exn (raise (exn:fail (string-append (expectation-out e) "err")
+                                   (current-continuation-marks)))
+                  "boom:err")
+      (commit-expectation! e))
+    (test-case "works with expect-unreachable"
+      (define e (make-expectation))
+      (with-expectation e (display "u"))
+      (when #f
+        (expect-unreachable (display (expectation-out e)))))))
+
+(module+ test
+  (run-tests expectation-tests))


### PR DESCRIPTION
## Summary
- refactor `capture-output` and expectation forms to use new struct helpers
- document `with-expectation` alongside existing forms
- show struct integration in README and manual
- test interaction with `expect`, `expect-file`, `expect-exn`, and `expect-unreachable`

## Testing
- `raco setup specs` *(fails: collection not found)*
- `raco setup -D recspecs`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_684b14138934832880e8a82bb8f58dec