### PR TITLE
Add recspecs-runner parameter

### DIFF
--- a/tests/runner.rkt
+++ b/tests/runner.rkt
@@ -1,0 +1,25 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs)
+
+(define (limit-memory thunk)
+  (call-in-nested-thread (lambda ()
+                           (custodian-limit-memory (current-custodian) (* 1024 1024))
+                           (thunk))))
+
+(define (capture-errors thunk)
+  (parameterize ([current-error-port (current-output-port)])
+    (thunk)))
+
+(define runner-tests
+  (test-suite "runner-tests"
+    (test-case "memory limit"
+      (parameterize ([recspecs-runner limit-memory])
+        (expect-exn (make-bytes (* 2 1024 1024)) "out of memory")))
+    (test-case "redirect errors"
+      (parameterize ([recspecs-runner capture-errors])
+        (expect (display "oops" (current-error-port)) "oops")))))
+
+(module+ test
+  (run-tests runner-tests))


### PR DESCRIPTION
## Summary
- add `recspecs-runner` parameter to customize how expectations run
- document the new parameter
- test memory limiting and error redirection via `recspecs-runner`

## Testing
- `raco make main.rkt tests/runner.rkt main.scrbl`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_684b1b1175748328a121d1eba79a585c