### PR TITLE
Improve expect update detection

### DIFF
--- a/emacs/recspecs.el
+++ b/emacs/recspecs.el
@@ -12,49 +12,51 @@
 
 (require 'subr-x)
 
-(defun
- recspecs--expect-pos
- ()
- "Return the character position of the expectation string at point.
+(defun recspecs--expect-pos ()
+  "Return the character position of the expectation string at point.
 Searches backward for an `expect` form and returns the position of its
 expectation string.  Signal an error if none is found."
- (save-excursion
-  (unless (re-search-backward
-           (rx (or (seq "(" (or "expect" "expect-exn" "expect-file") symbol-end)
-                   (seq "@" (? "(") (or "expect" "expect-exn" "expect-file") symbol-end)))
-           nil
-           t)
-    (error "No expect form found"))
-  (let ([start (point)])
-    (when (looking-at "@")
-      (forward-char 1)
+  (save-excursion
+    (unless (re-search-backward
+             (rx (or (seq "("
+                         (or "expect" "expect-exn" "expect-file")
+                         symbol-end)
+                     (seq "@" (? "(")
+                         (or "expect" "expect-exn" "expect-file")
+                         symbol-end)))
+             nil t)
+      (error "No expect form found"))
+    (let ((start (point)))
+      (when (looking-at "@")
+        (forward-char 1)
+        (when (looking-at "(")
+          (forward-char 1)))
       (when (looking-at "(")
-        (forward-char 1)))
-    (when (looking-at "(")
-      (forward-char 1)) ;; skip opening paren if present
-    (forward-symbol 1) ;; skip expect / expect-exn / expect-file
-    (skip-chars-forward "\s-")
-    (forward-sexp 1) ;; expression or path
-    (skip-chars-forward "\s-")
-    (if (looking-at "{")
-        (progn (forward-char 1)
-               (skip-chars-forward "\s-")
-               (if (looking-at "}")
-                   start
-                   (point)))
+        (forward-char 1)) ;; skip opening paren if present
+      (forward-symbol 1) ;; skip expect / expect-exn / expect-file
+      (skip-chars-forward "\s-")
+      (forward-sexp 1) ;; expression or path
+      (skip-chars-forward "\s-")
+      (if (looking-at "{")
+          (progn
+            (forward-char 1)
+            (skip-chars-forward "\s-")
+            (if (looking-at "}")
+                start
+              (point)))
         (point)))))
 
 ;;;###autoload
-(defun recspecs-update-at-point
-       ()
-       "Run `racket-test` with update flags for the expectation at point."
-       (interactive)
-       (let* ([file (buffer-file-name)]
-              [pos (recspecs--expect-pos)]
-              [env (list "RECSPECS_UPDATE=1" (format "RECSPECS_UPDATE_TEST=%s:%d" file pos))]
-              [process-environment (append env process-environment)])
-         (cond
-           [t (compile (format "raco test %s" (shell-quote-argument file)))])))
+(defun recspecs-update-at-point ()
+  "Run `racket-test` with update flags for the expectation at point."
+  (interactive)
+  (let* ((file (buffer-file-name))
+         (pos (recspecs--expect-pos))
+         (env (list "RECSPECS_UPDATE=1"
+                    (format "RECSPECS_UPDATE_TEST=%s:%d" file pos)))
+         (process-environment (append env process-environment)))
+    (cond
+     (t (compile (format "raco test %s" (shell-quote-argument file)))))))
 
 (provide 'recspecs)
 


### PR DESCRIPTION
## Summary
- handle @expect forms with empty braces in Emacs helper

## Testing
- `raco test -p recspecs`

------
https://chatgpt.com/codex/tasks/task_e_684c7d54ac988328a75c3b081a0a8eab