### PR TITLE
Run Emacs tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,15 @@ jobs:
           version: stable
           distribution: full
           architecture: x64
+      - name: Install Emacs
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y emacs-nox
       - name: Install packages
         run: raco pkg install --auto ./recspecs-lib ./recspecs
       - name: Build package
         run: raco setup --check-pkg-deps --unused-pkg-deps recspecs
       - name: Run tests
         run: raco test -p recspecs recspecs-lib
+      - name: Run Emacs tests
+        run: emacs --batch -L emacs -l emacs/recspecs-tests.el -f ert-run-tests-batch-and-exit

--- a/emacs/recspecs-tests.el
+++ b/emacs/recspecs-tests.el
@@ -1,0 +1,52 @@
+;;; recspecs-tests.el --- tests for recspecs.el -*- lexical-binding: t; -*-
+
+(require 'ert)
+(load-file (expand-file-name "recspecs.el" (file-name-directory (or load-file-name buffer-file-name))))
+
+(ert-deftest recspecs--expect-pos-curly ()
+  (with-temp-buffer
+    (insert "(expect (+ 1 2) { 3 })")
+    (goto-char (point-max))
+    (search-backward "3")
+    (should (= (recspecs--expect-pos) (point)))))
+
+(ert-deftest recspecs--expect-pos-string ()
+  (with-temp-buffer
+    (insert "(expect (display \"hi\") \"hi\")")
+    (goto-char (point-max))
+    (search-backward "\"hi\"")
+    (should (= (recspecs--expect-pos) (point)))))
+
+(ert-deftest recspecs--expect-pos-at-form ()
+  (with-temp-buffer
+    (insert "@expect (identity 1) {1}")
+    (goto-char (point-max))
+    (search-backward "1}")
+    (should (= (recspecs--expect-pos) (point)))))
+
+(ert-deftest recspecs--expect-pos-no-form ()
+  (with-temp-buffer
+    (insert "(display 1)")
+    (goto-char (point-max))
+    (should-error (recspecs--expect-pos))))
+
+(ert-deftest recspecs-update-at-point-calls-compile ()
+  (let ((compile-cmd nil)
+        (compile-env nil))
+    (cl-letf (((symbol-function 'compile)
+               (lambda (cmd)
+                 (setq compile-cmd cmd
+                       compile-env process-environment))))
+      (with-temp-buffer
+        (insert "(expect (display \"hi\") \"hi\")")
+        (goto-char (point-max))
+        (search-backward "\"hi\"")
+        (let ((buffer-file-name "/tmp/test.rkt"))
+          (recspecs-update-at-point))
+        (should (string-match "raco test" compile-cmd))
+        (should (member "RECSPECS_UPDATE=1" compile-env))
+        (should (seq-some (lambda (x) (string-match "^RECSPECS_UPDATE_TEST=/tmp/test.rkt:" x))
+                          compile-env))))))
+
+(provide 'recspecs-tests)
+;;; recspecs-tests.el ends here


### PR DESCRIPTION
## Summary
- add ERT-based tests for the Emacs helper functions
- install Emacs and run the Emacs tests in CI


------
https://chatgpt.com/codex/tasks/task_e_684c80d42a1083289bdee7f366349c08