### PR TITLE
Add more usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ You can also capture output directly without an expectation:
                #:stderr? 'both) ; => "warnout"
 ```
 
+### Additional examples
+
+Store expectations in a separate file with `expect-file`:
+
+```racket
+(expect-file
+  (begin
+    (displayln "hello")
+    (displayln "world"))
+  "expected.txt")
+```
+
+Check exception messages using `expect-exn`:
+
+```racket
+(expect-exn (raise-user-error "bad") "bad")
+```
+
+Transform output before comparison with `recspecs-output-filter`:
+
+```racket
+(parameterize ([recspecs-output-filter string-upcase])
+  (expect (display "ok") "OK"))
+```
+
 The library also exposes a mutable `expectation` value for recording
 output programmatically. Use `with-expectation` to capture output into the
 struct and call `commit-expectation!` or `skip-expectation!` to mark the

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -86,12 +86,21 @@ expectations:
 Reads the expectation from @racket[path-str] instead of embedding it in the
 source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.
 }
+@racketblock[
+  (expect-file
+    (begin
+      (displayln "hello")
+      (displayln "world"))
+    "expected.txt")]
 
 @defform[(expect-exn expr expected-str ...)]{
 Checks that @racket[expr] raises an exception whose message matches the
 concatenation of @racket[expected-str]s. The message is updated when
 update mode is enabled.
 }
+@racketblock[
+  (expect-exn (raise-user-error "bad")
+              "bad")]
 
 @defform[(expect-unreachable expr)]{
 Fails the enclosing test if @racket[expr] evaluates. When update mode is


### PR DESCRIPTION
## Summary
- document how to use `expect-file`
- give an example for `expect-exn`
- show how to modify output with `recspecs-output-filter`

## Testing
- `raco setup specs` *(fails: collection not found)*
- `raco setup -D recspecs`
- `raco test -p recspecs recspecs-lib`

------
https://chatgpt.com/codex/tasks/task_e_684f7152e31083288f61cabe769662d0