### PR TITLE
Add property tests without eval

### DIFF
--- a/recspecs-lib/main.rkt
+++ b/recspecs-lib/main.rkt
@@ -19,6 +19,10 @@
          expect-file
          expect-exn
          expect-unreachable
+         run-expect
+         run-expect-exn
+         run-expect-unreachable
+         update-file-entire
          with-expectation
          (contract-out (struct expectation ([out string?] [committed? boolean?] [skip? boolean?]))
                        [make-expectation (-> expectation?)]
@@ -367,6 +371,15 @@
                    #:strict s?
                    #:stderr? st?)]
     [(_ expr
+        expected
+        (~optional (~seq #:strict? s?) #:defaults ([s? #'#f]))
+        (~optional (~seq #:stderr? st?) #:defaults ([st? #'#f])))
+     #:declare expr (expr/c #'any/c)
+     #:declare expected (expr/c #'string?)
+     #:declare s? (expr/c #'boolean?)
+     #:declare st? (expr/c #'(or/c boolean? (symbols 'both)))
+     #'(run-expect (lambda () expr) expected #f 0 0 #:strict s? #:stderr? st?)]
+    [(_ expr
         (~optional (~seq #:strict? s?) #:defaults ([s? #'#f]))
         (~optional (~seq #:stderr? st?) #:defaults ([st? #'#f])))
      #:declare expr (expr/c #'any/c)
@@ -408,6 +421,26 @@
                      0
                      update-file-entire
                      #:strict s?
+                     #:stderr? st?))]
+    [(_ expr
+        path-exp
+        (~optional (~seq #:strict? s?) #:defaults ([s? #'#f]))
+        (~optional (~seq #:stderr? st?) #:defaults ([st? #'#f])))
+     #:declare expr (expr/c #'any/c)
+     #:declare path-exp (expr/c #'path-string?)
+     #:declare s? (expr/c #'boolean?)
+     #:declare st? (expr/c #'(or/c boolean? (symbols 'both)))
+     #'(let* ([p path-exp]
+              [p (if (path? p)
+                     p
+                     (string->path p))])
+         (run-expect (lambda () expr)
+                     (call-with-input-file p port->string)
+                     (path->string p)
+                     0
+                     0
+                     update-file-entire
+                     #:strict s?
                      #:stderr? st?))]))
 
 (define-syntax (expect-exn stx)
@@ -439,6 +472,15 @@
                        #,span
                        #:strict s?
                        #:stderr? st?)]
+    [(_ expr
+        expected
+        (~optional (~seq #:strict? s?) #:defaults ([s? #'#f]))
+        (~optional (~seq #:stderr? st?) #:defaults ([st? #'#f])))
+     #:declare expr (expr/c #'any/c)
+     #:declare expected (expr/c #'string?)
+     #:declare s? (expr/c #'boolean?)
+     #:declare st? (expr/c #'(or/c boolean? (symbols 'both)))
+     #'(run-expect-exn (lambda () expr) expected #f 0 0 #:strict s? #:stderr? st?)]
     [(_ expr
         (~optional (~seq #:strict? s?) #:defaults ([s? #'#f]))
         (~optional (~seq #:stderr? st?) #:defaults ([st? #'#f])))

--- a/recspecs/info.rkt
+++ b/recspecs/info.rkt
@@ -4,6 +4,6 @@
 
 (define scribblings (list (list "main.scrbl" (list 'multi-page) (list 'library) "recspecs")))
 
-(define deps (list "recspecs-lib" "rackunit-lib" "scribble-lib" "base" "at-exp-lib"))
+(define deps (list "recspecs-lib" "rackunit-lib" "scribble-lib" "base" "at-exp-lib" "rackcheck-lib"))
 
 (define build-deps (list "racket-doc" "scribble-doc"))

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -163,3 +163,39 @@ access the captured output with @racket[expectation-out]:
   (displayln (expectation-out log))]
 
 
+@defproc[(run-expect
+          [thunk (-> any/c)]
+          [expected string?]
+          [path (or/c path-string? #f)]
+          [pos exact-nonnegative-integer?]
+          [span exact-nonnegative-integer?]
+          [#:strict strict? boolean? #f]
+          [#:stderr? stderr? (or/c boolean? (symbols 'both))])
+         void?]{
+Runs @racket[thunk] and checks that the captured output matches
+@racket[expected].  The @racket[path], @racket[pos] and @racket[span]
+identify the source location used when updating.
+}
+
+@defproc[(run-expect-exn
+          [thunk (-> any/c)]
+          [expected string?]
+          [path (or/c path-string? #f)]
+          [pos exact-nonnegative-integer?]
+          [span exact-nonnegative-integer?]
+          [#:strict strict? boolean? #f]
+          [#:stderr? stderr? (or/c boolean? (symbols 'both))])
+         void?]{
+Like @racket[run-expect] but expects @racket[thunk] to raise an
+exception whose message matches @racket[expected].
+}
+
+@defproc[(update-file-entire
+          [path path-string?]
+          [pos exact-nonnegative-integer?]
+          [span exact-nonnegative-integer?]
+          [new-str string?])
+         void?]{
+Replace the entire file at @racket[path] with @racket[new-str].
+}
+

--- a/recspecs/tests/property-capture-output.rkt
+++ b/recspecs/tests/property-capture-output.rkt
@@ -1,0 +1,50 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         rackcheck
+         recspecs)
+
+(define prop-capture-output
+  (property ([s (gen:string)]) (string=? (capture-output (lambda () (display s))) s)))
+
+(define prop-capture-stderr
+  (property ([s (gen:string)])
+            (string=? (capture-output (lambda () (display s (current-error-port))) #:stderr? #t) s)))
+
+(define prop-capture-both
+  (property ([s1 (gen:string)] [s2 (gen:string)])
+            (string=? (capture-output (lambda ()
+                                        (display s1 (current-error-port))
+                                        (display s2))
+                                      #:stderr? 'both)
+                      (string-append s1 s2))))
+
+;; Non-string values
+(define prop-capture-number
+  (property ([n (gen:integer-in -1000 1000)])
+            (string=? (capture-output (lambda () (display n))) (number->string n))))
+
+(define prop-capture-number-stderr
+  (property ([n (gen:integer-in -1000 1000)])
+            (string=? (capture-output (lambda () (display n (current-error-port))) #:stderr? #t)
+                      (number->string n))))
+
+(define prop-capture-number-both
+  (property ([n1 (gen:integer-in -1000 1000)] [n2 (gen:integer-in -1000 1000)])
+            (string=? (capture-output (lambda ()
+                                        (display n1 (current-error-port))
+                                        (display n2))
+                                      #:stderr? 'both)
+                      (string-append (number->string n1) (number->string n2)))))
+
+(define property-tests
+  (test-suite "property-capture-output"
+    (check-property prop-capture-output)
+    (check-property prop-capture-stderr)
+    (check-property prop-capture-both)
+    (check-property prop-capture-number)
+    (check-property prop-capture-number-stderr)
+    (check-property prop-capture-number-both)))
+
+(module+ test
+  (run-tests property-tests))

--- a/recspecs/tests/property-expect.rkt
+++ b/recspecs/tests/property-expect.rkt
@@ -1,0 +1,54 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         racket/file
+         rackcheck
+         recspecs)
+
+;; Expect with strings
+(define prop-expect-string (property ([s (gen:string)]) (expect (display s) s) #t))
+
+;; Expect with numbers
+(define prop-expect-number
+  (property ([n (gen:integer-in -1000 1000)]) (expect (display n) (number->string n)) #t))
+
+;; Expect-exn with strings
+(define prop-expect-exn-string
+  (property ([s (gen:string)]) (expect-exn (raise (exn:fail s (current-continuation-marks))) s) #t))
+
+;; Expect-exn with numbers
+(define prop-expect-exn-number
+  (property ([n (gen:integer-in -1000 1000)])
+            (expect-exn (raise (exn:fail (number->string n) (current-continuation-marks)))
+                        (number->string n))
+            #t))
+
+;; Expect-file with strings
+(define prop-expect-file-string
+  (property ([s (gen:string)])
+            (define tmp (make-temporary-file "exp~a.txt"))
+            (call-with-output-file tmp #:exists 'truncate/replace (lambda (out) (display s out)))
+            (expect-file (display s) (path->string tmp))
+            (delete-file tmp)
+            #t))
+
+;; Expect-file with numbers
+(define prop-expect-file-number
+  (property ([n (gen:integer-in -1000 1000)])
+            (define tmp (make-temporary-file "exp~a.txt"))
+            (call-with-output-file tmp #:exists 'truncate/replace (lambda (out) (display n out)))
+            (expect-file (display n) (path->string tmp))
+            (delete-file tmp)
+            #t))
+
+(define property-tests
+  (test-suite "property-expect"
+    (check-property prop-expect-string)
+    (check-property prop-expect-number)
+    (check-property prop-expect-exn-string)
+    (check-property prop-expect-exn-number)
+    (check-property prop-expect-file-string)
+    (check-property prop-expect-file-number)))
+
+(module+ test
+  (run-tests property-tests))


### PR DESCRIPTION
## Summary
- allow `expect`, `expect-exn`, and `expect-file` to accept dynamic values
- rewrite property-based tests for expectations without `eval`

## Testing
- `raco make recspecs/tests/property-expect.rkt`
- `raco test recspecs/tests/property-expect.rkt`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_6851a543c8308328912ed456edcf515a