### PR TITLE
Add expect/print and expect/pretty forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Additional forms mirror features from the OCaml and Rust libraries:
 * `expect-exn` checks that an expression raises an exception with a given
   message.
 * `expect-unreachable` fails if the wrapped expression is evaluated.
+* `expect/print` runs `expr`, prints the result with `print`, and compares
+  the printed output.
+* `expect/pretty` is like `expect/print` but uses `pretty-print`, so the
+  expectation includes a trailing newline.
 * All expectation forms accept multiple string arguments which are
   concatenated together. This is handy when using
   `#lang at-exp` for multi-line expectations.
@@ -99,6 +103,13 @@ Check exception messages using `expect-exn`:
 
 ```racket
 (expect-exn (raise-user-error "bad") "bad")
+```
+
+Automatically print a value before comparing:
+
+```racket
+(expect/print (+ 1 2) "3")
+(expect/pretty '(1 2 3) "(1 2 3)\n")
 ```
 
 Transform output before comparison with `recspecs-output-filter`:

--- a/recspecs-lib/main.rkt
+++ b/recspecs-lib/main.rkt
@@ -7,15 +7,20 @@
          racket/vector
          racket/match
          racket/path
+         racket/pretty
          rackunit
          racket/contract
+         syntax/parse/define
          (for-syntax racket/base
                      syntax/parse
+                     syntax/parse/define
                      syntax/parse/experimental/contract
                      racket/list
                      racket/file))
 
 (provide expect
+         expect/print
+         expect/pretty
          expect-file
          expect-exn
          expect-unreachable
@@ -512,3 +517,9 @@
      (define span (syntax-span stx))
      (define expr-str (format "~s" (syntax->datum #'expr)))
      #`(run-expect-unreachable #,expr-str #,(and src (path->string src)) #,pos #,span)]))
+
+(define-syntax-parse-rule (expect/print expr arg ...)
+  (expect (print expr) arg ...))
+
+(define-syntax-parse-rule (expect/pretty expr arg ...)
+  (expect (pretty-print expr) arg ...))

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -88,6 +88,18 @@ expectations:
   hello
   3}]
 
+@defform[(expect/print expr expected-str ...)]{
+Like @racket[expect], but the result of @racket[expr] is printed with
+@racket[print] before comparison.  This is shorthand for
+@racket[(expect (print expr) expected-str ...)].
+}
+
+@defform[(expect/pretty expr expected-str ...)]{
+Like @racket[expect/print], but uses @racket[pretty-print] to output the
+result.  The newline produced by @racket[pretty-print] is included in the
+expectation.
+}
+
 @defform[(expect-file expr path-str)]{
 Reads the expectation from @racket[path-str] instead of embedding it in the
 source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.

--- a/recspecs/tests/expect.rkt
+++ b/recspecs/tests/expect.rkt
@@ -18,6 +18,10 @@
     (expect (display "hello") "  hello  \n")
     ;; Strict matching
     (expect (display "strict") "strict" #:strict? #t)
+    (expect/print (+ 1 1) "2")
+    (expect/pretty (list 1 2) "'(1 2)\n")
+    (parameterize ([pretty-print-columns 3])
+      (expect/pretty (list 1 2 3 4) "'(1\n  2\n  3\n  4)\n"))
     (expect-exn (raise (exn:fail "oops" (current-continuation-marks))) "oops")))
 
 ;; Macro expansion with no expectation should not error


### PR DESCRIPTION
## Summary
- support automatically printing values with `expect/print`
- add `expect/pretty` for pretty-printing results
- document the new forms in the manual and README
- test the new forms

## Testing
- `raco make recspecs-lib/main.rkt recspecs/tests/expect.rkt`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_685eb44b62888328b0767976fffe167e