### PR TITLE
Add expect/shell form

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Additional forms mirror features from the OCaml and Rust libraries:
   the printed output.
 * `expect/pretty` is like `expect/print` but uses `pretty-print`, so the
   expectation includes a trailing newline.
+* `expect/shell` from `recspecs/shell` runs an external command and compares
+  the session against a transcript. Lines beginning with `>` are sent to the
+  command's input.
 * All expectation forms accept multiple string arguments which are
   concatenated together. This is handy when using
   `#lang at-exp` for multi-line expectations.
@@ -110,6 +113,12 @@ Automatically print a value before comparing:
 ```racket
 (expect/print (+ 1 2) "3")
 (expect/pretty '(1 2 3) "(1 2 3)\n")
+@expect/shell["cat"]{
+> hi
+hi
+> there
+there
+}
 ```
 
 Transform output before comparison with `recspecs-output-filter`:

--- a/recspecs-lib/shell.rkt
+++ b/recspecs-lib/shell.rkt
@@ -1,0 +1,97 @@
+#lang racket/base
+(require racket/system
+         racket/port
+         racket/match
+         racket/string
+         racket/list
+         "main.rkt"
+         syntax/parse/define
+         (for-syntax racket/base
+                     syntax/parse
+                     syntax/parse/define
+                     racket/list))
+
+(provide expect/shell)
+
+(define (parse-transcript str)
+  (define lines (regexp-split #px"\r?\n" str))
+  (when (and (pair? lines) (string=? (last lines) ""))
+    (set! lines (drop-right lines 1)))
+  (define entries '())
+  (define current #f)
+  (define outs '())
+  (for ([l lines])
+    (match (regexp-match #px"^>\\s*(.*)$" l)
+      [(list _ cmd)
+       (when current
+         (set! entries (append entries (list (cons current outs)))))
+       (set! current (string-trim cmd))
+       (set! outs '())]
+      [#f (set! outs (append outs (list l)))]))
+  (when current
+    (set! entries (append entries (list (cons current outs)))))
+  entries)
+
+(define (shell-run cmd transcript)
+  (define steps (parse-transcript transcript))
+  (define-values (out in pid err ctrl)
+    (apply values
+           (if (list? cmd)
+               (apply process* cmd)
+               (process cmd))))
+  (for ([step steps])
+    (define input (car step))
+    (display "> ")
+    (displayln input)
+    (with-handlers ([exn:fail:filesystem? (lambda (e) (void))])
+      (display input in)
+      (newline in)
+      (flush-output in))
+    (for ([ign (in-list (cdr step))])
+      (define line (read-line out))
+      (unless (eof-object? line)
+        (displayln line))))
+  (close-output-port in)
+  (let loop ()
+    (define line (read-line out))
+    (unless (eof-object? line)
+      (displayln line)
+      (loop)))
+  (ctrl 'wait))
+
+(define (run-expect-shell cmd transcript path pos span #:strict [strict? #f])
+  (run-expect (lambda () (shell-run cmd transcript)) transcript path pos span #:strict strict?))
+
+(define-syntax (expect/shell stx)
+  (syntax-parse stx
+    [(_ cmd
+        expected-first:str
+        expected-rest:str ...
+        (~optional (~seq #:strict? s?) #:defaults ([s? #'#f])))
+     #:declare cmd (expr/c #'any/c)
+     #:declare s? (expr/c #'boolean?)
+     (define expect-list (syntax->list #'(expected-first expected-rest ...)))
+     (define first #'expected-first)
+     (define last-syn
+       (if (null? (syntax->list #'(expected-rest ...)))
+           #'expected-first
+           (last expect-list)))
+     (define src (syntax-source first))
+     (define pos (or (syntax-position first) 0))
+     (define span
+       (- (+ (or (syntax-position last-syn) 0)
+             (or (syntax-span last-syn) (string-length (syntax-e last-syn))))
+          pos))
+     #`(run-expect-shell cmd
+                         (string-append #,@expect-list)
+                         #,(and src (path->string src))
+                         #,pos
+                         #,span
+                         #:strict s?)]
+    [(_ cmd (~optional (~seq #:strict? s?) #:defaults ([s? #'#f])))
+     #:declare cmd (expr/c #'any/c)
+     #:declare s? (expr/c #'boolean?)
+     (define src (syntax-source stx))
+     (define pos (syntax-position stx))
+     (define span (syntax-span stx))
+     #'(run-expect-shell cmd "" #,(and src (path->string src)) #,pos #,span #:strict s?)]))

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -211,3 +211,22 @@ exception whose message matches @racket[expected].
 Replace the entire file at @racket[path] with @racket[new-str].
 }
 
+@section{Shell Commands}
+@defmodule[recspecs/shell]
+
+@defform[(expect/shell cmd-expr expected-str ...)]{
+Run @racket[cmd-expr] as a subprocess and compare the interaction
+against @racket[expected-str ...].  Lines in the expectation that begin
+with @litchar{>} are sent to the process as input (without the prompt).
+The command's responses are captured and the full transcript is checked
+against the expectation.
+}
+@racketblock[
+  (require recspecs/shell)
+  @expect/shell["cat"]{
+  > hi
+  hi
+  > there
+  there
+  }
+]

--- a/recspecs/tests/shell.rkt
+++ b/recspecs/tests/shell.rkt
@@ -1,0 +1,14 @@
+#lang racket
+(require rackunit
+         rackunit/text-ui
+         recspecs/shell)
+
+(define shell-tests
+  (test-suite "shell-tests"
+    (test-case "cat session"
+      (expect/shell "cat" "> hi\nhi\n> there\nthere\n"))
+    (test-case "strict output"
+      (expect/shell "cat" "> ok\nok\n" #:strict? #t))))
+
+(module+ test
+  (run-tests shell-tests))


### PR DESCRIPTION
## Summary
- add `expect/shell` in new `recspecs/shell` module
- document shell expectations in manual and README
- show example usage
- test shell interaction with `cat`
- improve shell expect tests and docs

## Testing
- `raco make recspecs-lib/shell.rkt recspecs/tests/shell.rkt recspecs/main.scrbl`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_6862a5159fac8328a99462fe0464ca9c