### PR TITLE
Fix duplicate doc entry

### DIFF
--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -152,7 +152,6 @@ Represents recorded output that can be committed or skipped. The
 structure is mutable so repeated @racket[with-expectation] blocks can
 append to @racket[out].}
 
-@defproc[(make-expectation) expectation?]{Create a fresh expectation.}
 
 @defproc[(commit-expectation! [e expectation?]) void?]{Mark @racket[e] as committed.}
 


### PR DESCRIPTION
## Summary
- remove redundant `make-expectation` definition from the manual

## Testing
- `raco make recspecs/main.scrbl`
- `raco setup recspecs`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_686bccf501988328aa3a7130bcb55d2a