### PR TITLE
Add bc shim and improve shell docs

### DIFF
--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -216,7 +216,7 @@ Replace the entire file at @racket[path] with @racket[new-str].
 The @racket[recspecs/shell] module provides tools for testing interactive shell 
 commands, inspired by the Unix @exec{expect} tool. It supports both simple transcript-based 
 testing and advanced pattern-based automation.
-
+Lines beginning with @litchar{>} in a transcript are sent to the subprocess while the remaining text is compared against its output. Pattern mode adds exact and regular expression matching, glob wildcards, per-pattern timeouts, and user-defined actions.
 @subsection{Basic Shell Testing}
 
 @defform[(expect/shell cmd-expr expected-str ...)]{

--- a/recspecs/tests/README.md
+++ b/recspecs/tests/README.md
@@ -1,0 +1,11 @@
+# Test Utilities
+
+This directory contains auxiliary scripts used by the test suite.
+
+## `bc.rkt`
+
+A lightweight calculator implemented in Racket to mimic the basic
+`bc` command. It supports addition, multiplication, division,
+exponentiation using `^`, parentheses, and the `scale` variable for
+setting decimal precision. The script reads expressions from standard
+input and prints results, exiting when the input is `quit`.

--- a/recspecs/tests/bc.rkt
+++ b/recspecs/tests/bc.rkt
@@ -1,0 +1,95 @@
+#lang racket
+;; Simple bc replacement for tests
+(module+ main
+  (define scale 0)
+
+  ;; Tokenize an expression into numbers and operators
+  (define (tokenize s)
+    (regexp-match* #px"[0-9]+|[+*/^()-]" s))
+
+  ;; Forward declarations for mutually recursive parsers
+  (define parse-expr #f)
+  (define parse-term #f)
+  (define parse-power #f)
+  (define parse-factor #f)
+
+  (set! parse-factor
+        (lambda (tokens)
+          (match tokens
+            [(cons "(" rest)
+             (define-values (v rest2) (parse-expr rest))
+             (unless (and rest2 (equal? (car rest2) ")"))
+               (error 'bc "missing )"))
+             (values v (cdr rest2))]
+            [(cons n rest) (values (string->number n) rest)]
+            [else (error 'bc "bad factor")])))
+
+  (set! parse-power
+        (lambda (tokens)
+          (define-values (base rest) (parse-factor tokens))
+          (match rest
+            [(cons "^" r)
+             (define-values (exp r2) (parse-power r))
+             (values (expt base exp) r2)]
+            [else (values base rest)])))
+
+  (set! parse-term
+        (lambda (tokens)
+          (define-values (v rest) (parse-power tokens))
+          (let loop ([v v]
+                     [t rest])
+            (match t
+              [(cons "*" r)
+               (define-values (rhs r2) (parse-power r))
+               (loop (* v rhs) r2)]
+              [(cons "/" r)
+               (define-values (rhs r2) (parse-power r))
+               (loop (/ v rhs) r2)]
+              [else (values v t)]))))
+
+  (set! parse-expr
+        (lambda (tokens)
+          (define-values (v rest) (parse-term tokens))
+          (let loop ([v v]
+                     [t rest])
+            (match t
+              [(cons "+" r)
+               (define-values (rhs r2) (parse-term r))
+               (loop (+ v rhs) r2)]
+              [(cons "-" r)
+               (define-values (rhs r2) (parse-term r))
+               (loop (- v rhs) r2)]
+              [else (values v t)]))))
+
+  (define (format-result n)
+    (cond
+      [(integer? n)
+       (printf "~a\n" n)
+       (flush-output)]
+      [else
+       (if (> scale 0)
+           (printf "~a\n" (real->decimal-string n scale))
+           (printf "~a\n" (inexact->exact (truncate n))))
+       (flush-output)]))
+
+  (define (eval-line line)
+    (cond
+      [(regexp-match #px"^scale=([0-9]+)$" line)
+       =>
+       (lambda (m) (set! scale (string->number (cadr m))))]
+      [else
+       (define tokens (tokenize line))
+       (define-values (result rest) (parse-expr tokens))
+       (when rest
+         (void))
+       (format-result result)]))
+
+  (let loop ()
+    (define line (read-line))
+    (cond
+      [(eof-object? line) (void)]
+      [(equal? line "quit") (void)]
+      [else
+       (with-handlers ([exn:fail? (lambda (_) (printf "error\n"))])
+         (eval-line (string-trim line)))
+       (loop)])))

--- a/recspecs/tests/shell.rkt
+++ b/recspecs/tests/shell.rkt
@@ -2,6 +2,7 @@
 (require rackunit
          rackunit/text-ui
          recspecs/shell)
+(define bc-path (path->string (collection-file-path "bc.rkt" "recspecs" "tests")))
 
 (define shell-tests
   (test-suite "shell-tests"
@@ -17,21 +18,21 @@ ok
 
 })
     (test-case "bc calculator basic"
-      @expect/shell["bc"]{> 2+3
+      @expect/shell[(list "racket" bc-path)]{> 2+3
 5
 > 10*4
 40
 > quit
 })
     (test-case "bc calculator with division"
-      @expect/shell["bc"]{> 15/3
+      @expect/shell[(list "racket" bc-path)]{> 15/3
 5
 > 22/7
 3
 > quit
 })
     (test-case "bc calculator complex session"
-      @expect/shell["bc"]{> 2^8
+      @expect/shell[(list "racket" bc-path)]{> 2^8
 256
 > (5+3)*2
 16

--- a/recspecs/tests/shell.rkt
+++ b/recspecs/tests/shell.rkt
@@ -3,6 +3,8 @@
          rackunit/text-ui
          recspecs/shell)
 (define bc-path (path->string (collection-file-path "bc.rkt" "recspecs" "tests")))
+(define racket-path
+  (path->string (find-executable-path "racket")))
 
 (define shell-tests
   (test-suite "shell-tests"
@@ -18,21 +20,21 @@ ok
 
 })
     (test-case "bc calculator basic"
-      @expect/shell[(list "racket" bc-path)]{> 2+3
+      @expect/shell[(list racket-path bc-path)]{> 2+3
 5
 > 10*4
 40
 > quit
 })
     (test-case "bc calculator with division"
-      @expect/shell[(list "racket" bc-path)]{> 15/3
+      @expect/shell[(list racket-path bc-path)]{> 15/3
 5
 > 22/7
 3
 > quit
 })
     (test-case "bc calculator complex session"
-      @expect/shell[(list "racket" bc-path)]{> 2^8
+      @expect/shell[(list racket-path bc-path)]{> 2^8
 256
 > (5+3)*2
 16


### PR DESCRIPTION
## Summary
- document shell tools in the manual instead of the README
- trim README section about shell usage
- add flushing and decimal output to bc test shim

## Testing
- `raco make recspecs/tests/bc.rkt recspecs/tests/shell.rkt recspecs-lib/shell.rkt recspecs/main.scrbl`
- `raco test -p recspecs`


------
https://chatgpt.com/codex/tasks/task_e_68786f3cc47c8328ae8f50fa7711b4ff