### PR TITLE
Fix recspecs package dependency on recspecs-lib

### DIFF
--- a/recspecs/info.rkt
+++ b/recspecs/info.rkt
@@ -6,6 +6,8 @@
 
 (define deps (list "recspecs-lib" "rackunit-lib" "scribble-lib" "base" "at-exp-lib" "rackcheck-lib"))
 
+(define implies (list "recspecs-lib"))
+
 (define build-deps (list "racket-doc" "scribble-doc"))
 
 (define license 'Apache-2.0)


### PR DESCRIPTION
Add the implies declaration so that installing recspecs automatically installs recspecs-lib, ensuring users get the library implementation.