### PR TITLE
Fix file corruption when updating multiple @expect forms (#57)

### DIFF
--- a/recspecs-lib/main.rkt
+++ b/recspecs-lib/main.rkt
@@ -29,6 +29,7 @@
          run-expect-unreachable
          update-file-entire
          with-expectation
+         flush-pending-updates!
          (contract-out (struct expectation ([out string?] [committed? boolean?] [skip? boolean?]))
                        [make-expectation (-> expectation?)]
                        [commit-expectation! (-> expectation? void?)]
@@ -137,6 +138,45 @@
          (if filter
              (and name (string-contains? name filter))
              #t))))
+
+;; ----------------------------------------------------------------------
+;; Offset tracking for file updates
+;;
+;; When multiple @expect forms in the same file need updating, earlier updates
+;; change the file size, making later positions stale. We track cumulative
+;; offsets per file so positions can be adjusted correctly.
+;;
+;; This approach updates immediately (no batching needed) which avoids
+;; module instance sharing issues with dynamic-require.
+
+;; Hash from file path to cumulative byte offset (how much file has grown/shrunk)
+(define file-offsets (make-hash))
+
+;; Apply an update with offset adjustment
+(define (apply-update-with-offset path pos span new-str update-fn)
+  (define offset (hash-ref file-offsets path 0))
+  (define adjusted-pos (+ pos offset))
+  ;; Measure actual file size before update
+  (define size-before (file-size path))
+  ;; Update the file at the adjusted position
+  (update-fn path adjusted-pos span new-str)
+  ;; Measure actual file size after update to get true size change
+  ;; This is more robust than calculating from span/new-str because different
+  ;; update functions replace different amounts of content (e.g., update-file-empty
+  ;; only replaces {} not the entire span)
+  (define size-after (file-size path))
+  (define size-change (- size-after size-before))
+  ;; Track the cumulative offset for future updates in this file
+  (hash-set! file-offsets path (+ offset size-change)))
+
+;; Helper to get UTF-8 byte length of a string
+(define (string-utf-8-length s)
+  (bytes-length (string->bytes/utf-8 s)))
+
+;; Flush is now a no-op since updates are applied immediately,
+;; but we keep it for API compatibility and to reset offsets
+(define (flush-pending-updates!)
+  (hash-clear! file-offsets))
 
 (define (update-file path pos span new-str)
   ;; Replace the expectation string located at [pos, pos+span) in the file
@@ -275,7 +315,7 @@
     (define equal? (comparator expected actual))
     (cond
       [(and path (update-mode? name) (not equal?))
-       (update path pos span actual)
+       (apply-update-with-offset path pos span actual update)
        (commit-expectation! e)
        (printf "Updated expectation in ~a\n" path)]
       [equal?
@@ -315,7 +355,7 @@
     (define equal? (comparator expected actual))
     (cond
       [(and path (update-mode? name) (not equal?))
-       (update path pos span actual)
+       (apply-update-with-offset path pos span actual update)
        (commit-expectation! e)
        (printf "Updated expectation in ~a\n" path)]
       [equal?
@@ -339,7 +379,7 @@
     (define e (make-expectation))
     (cond
       [(and path (update-mode? name))
-       (update-file-rewrite path pos span expr-str)
+       (apply-update-with-offset path pos span expr-str update-file-rewrite)
        (commit-expectation! e)
        (printf "Updated expectation in ~a\n" path)]
       [else

--- a/recspecs/tests/expect.rkt
+++ b/recspecs/tests/expect.rkt
@@ -76,22 +76,18 @@
   (test-suite "at-exp-empty-tests"
     (test-case "updates empty at-exp braces"
       (define tmp (make-temporary-file "tmp~a.rkt"))
-      (define main-path (build-path (current-directory) ".." ".." "recspecs-lib" "main.rkt"))
       (call-with-output-file
        tmp
        #:exists 'truncate/replace
        (lambda (out)
-         (fprintf out
-                  "#lang at-exp racket\n(require (file \"~a\"))\n@expect[(displayln \"foo\")]{}\n"
-                  (path->string main-path))))
+         (display "#lang at-exp racket\n(require recspecs)\n@expect[(displayln \"foo\")]{}\n" out)))
       (putenv "RECSPECS_UPDATE" "1")
       (dynamic-require tmp #f)
+      (flush-pending-updates!)
       (putenv "RECSPECS_UPDATE" "")
       (define expected
         (string-append "#lang at-exp racket\n"
-                       "(require (file \""
-                       (path->string main-path)
-                       "\"))\n"
+                       "(require recspecs)\n"
                        "@expect[(displayln \"foo\")]{"
                        "foo\n"
                        "}\n"))
@@ -113,6 +109,7 @@
       (putenv "RECSPECS_UPDATE" "1")
       (putenv "RECSPECS_UPDATE_TEST" tmp-str)
       (dynamic-require tmp #f)
+      (flush-pending-updates!)
       (putenv "RECSPECS_UPDATE" "")
       (putenv "RECSPECS_UPDATE_TEST" "")
       (define expected
@@ -136,12 +133,156 @@
       (putenv "RECSPECS_UPDATE" "1")
       (putenv "RECSPECS_UPDATE_TEST" tmp-str)
       (dynamic-require tmp #f)
+      (flush-pending-updates!)
       (putenv "RECSPECS_UPDATE" "")
       (putenv "RECSPECS_UPDATE_TEST" "")
       (define expected
         (string-append "#lang at-exp racket/base\n"
                        "(require recspecs)\n\n"
                        "@expect[(print 400)]{\n 400\n}\n"))
+      (check-equal? (file->string tmp) expected))))
+
+;; Regression test for issue #57: File corruption when RECSPECS_UPDATE=1
+;; updates multiple @expect forms in the same file. Previously, byte positions
+;; would become stale after the first update, causing subsequent updates to
+;; corrupt the file. The fix tracks cumulative offsets per file.
+(define multi-update-tests
+  (test-suite "multi-update-tests"
+    (test-case "updates multiple expect forms without corruption"
+      (define tmp (make-temporary-file "multi~a.rkt"))
+      (call-with-output-file tmp
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (display "#lang at-exp racket/base\n" out)
+                               (display "(require recspecs)\n\n" out)
+                               ;; Three @expect forms that all need updating
+                               (display "@expect[(displayln \"first\")]{}\n" out)
+                               (display "@expect[(displayln \"second\")]{}\n" out)
+                               (display "@expect[(displayln \"third\")]{}\n" out)))
+      (define tmp-str (path->string tmp))
+      (putenv "RECSPECS_UPDATE" "1")
+      (putenv "RECSPECS_UPDATE_TEST" tmp-str)
+      (dynamic-require tmp #f)
+      (flush-pending-updates!)
+      (putenv "RECSPECS_UPDATE" "")
+      (putenv "RECSPECS_UPDATE_TEST" "")
+      (define expected
+        (string-append "#lang at-exp racket/base\n"
+                       "(require recspecs)\n\n"
+                       "@expect[(displayln \"first\")]{first\n}\n"
+                       "@expect[(displayln \"second\")]{second\n}\n"
+                       "@expect[(displayln \"third\")]{third\n}\n"))
+      (check-equal? (file->string tmp) expected))
+
+    ;; Test with varying output sizes to stress offset tracking
+    (test-case "handles varying output sizes correctly"
+      (define tmp (make-temporary-file "vary~a.rkt"))
+      (call-with-output-file tmp
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (display "#lang at-exp racket/base\n" out)
+                               (display "(require recspecs)\n\n" out)
+                               ;; Short, very long, then short output
+                               (display "@expect[(display \"a\")]{}\n" out)
+                               (display "@expect[(display (make-string 100 #\\x))]{}\n" out)
+                               (display "@expect[(display \"b\")]{}\n" out)))
+      (define tmp-str (path->string tmp))
+      (putenv "RECSPECS_UPDATE" "1")
+      (putenv "RECSPECS_UPDATE_TEST" tmp-str)
+      (dynamic-require tmp #f)
+      (flush-pending-updates!)
+      (putenv "RECSPECS_UPDATE" "")
+      (putenv "RECSPECS_UPDATE_TEST" "")
+      (define expected
+        (string-append "#lang at-exp racket/base\n"
+                       "(require recspecs)\n\n"
+                       "@expect[(display \"a\")]{a}\n"
+                       "@expect[(display (make-string 100 #\\x))]{" (make-string 100 #\x) "}\n"
+                       "@expect[(display \"b\")]{b}\n"))
+      (check-equal? (file->string tmp) expected))
+
+    ;; Note: Unicode content with multi-byte characters has known issues
+    ;; with at-exp syntax position tracking. This test verifies ASCII-only
+    ;; multi-update works. Unicode support may need separate investigation.
+
+    ;; Test with many @expect forms to stress test offset accumulation
+    (test-case "handles many expect forms"
+      (define tmp (make-temporary-file "many~a.rkt"))
+      (call-with-output-file tmp
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (display "#lang at-exp racket/base\n" out)
+                               (display "(require recspecs)\n\n" out)
+                               ;; 10 @expect forms
+                               (for ([i (in-range 10)])
+                                 (fprintf out "@expect[(display ~a)]{}\n" i))))
+      (define tmp-str (path->string tmp))
+      (putenv "RECSPECS_UPDATE" "1")
+      (putenv "RECSPECS_UPDATE_TEST" tmp-str)
+      (dynamic-require tmp #f)
+      (flush-pending-updates!)
+      (putenv "RECSPECS_UPDATE" "")
+      (putenv "RECSPECS_UPDATE_TEST" "")
+      (define expected
+        (string-append "#lang at-exp racket/base\n"
+                       "(require recspecs)\n\n"
+                       (apply string-append
+                              (for/list ([i (in-range 10)])
+                                (format "@expect[(display ~a)]{~a}\n" i i)))))
+      (check-equal? (file->string tmp) expected))
+
+    ;; Test updating stale expectations (non-empty braces)
+    (test-case "updates stale expectations correctly"
+      (define tmp (make-temporary-file "stale~a.rkt"))
+      (call-with-output-file tmp
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (display "#lang at-exp racket/base\n" out)
+                               (display "(require recspecs)\n\n" out)
+                               ;; Expectations with wrong/outdated content
+                               (display "@expect[(display \"new1\")]{old1}\n" out)
+                               (display "@expect[(display \"new2\")]{old2}\n" out)
+                               (display "@expect[(display \"new3\")]{old3}\n" out)))
+      (define tmp-str (path->string tmp))
+      (putenv "RECSPECS_UPDATE" "1")
+      (putenv "RECSPECS_UPDATE_TEST" tmp-str)
+      (dynamic-require tmp #f)
+      (flush-pending-updates!)
+      (putenv "RECSPECS_UPDATE" "")
+      (putenv "RECSPECS_UPDATE_TEST" "")
+      (define expected
+        (string-append "#lang at-exp racket/base\n"
+                       "(require recspecs)\n\n"
+                       "@expect[(display \"new1\")]{new1}\n"
+                       "@expect[(display \"new2\")]{new2}\n"
+                       "@expect[(display \"new3\")]{new3}\n"))
+      (check-equal? (file->string tmp) expected))
+
+    ;; Test with quoted string syntax (regular racket, not at-exp)
+    (test-case "updates quoted string expectations correctly"
+      (define tmp (make-temporary-file "quoted~a.rkt"))
+      (call-with-output-file tmp
+                             #:exists 'truncate/replace
+                             (lambda (out)
+                               (display "#lang racket/base\n" out)
+                               (display "(require recspecs)\n\n" out)
+                               ;; Regular quoted string expectations
+                               (display "(expect (display \"hello\") \"wrong1\")\n" out)
+                               (display "(expect (display \"world\") \"wrong2\")\n" out)
+                               (display "(expect (display \"test\") \"wrong3\")\n" out)))
+      (define tmp-str (path->string tmp))
+      (putenv "RECSPECS_UPDATE" "1")
+      (putenv "RECSPECS_UPDATE_TEST" tmp-str)
+      (dynamic-require tmp #f)
+      (flush-pending-updates!)
+      (putenv "RECSPECS_UPDATE" "")
+      (putenv "RECSPECS_UPDATE_TEST" "")
+      (define expected
+        (string-append "#lang racket/base\n"
+                       "(require recspecs)\n\n"
+                       "(expect (display \"hello\") \"hello\")\n"
+                       "(expect (display \"world\") \"world\")\n"
+                       "(expect (display \"test\") \"test\")\n"))
       (check-equal? (file->string tmp) expected))))
 
 (module+ test
@@ -151,4 +292,5 @@
                syntax-error-tests
                at-exp-empty-tests
                at-exp-base-tests
-               at-exp-newline-tests)))
+               at-exp-newline-tests
+               multi-update-tests)))


### PR DESCRIPTION
When RECSPECS_UPDATE=1 updates multiple @expect forms in a single file,
earlier updates change the file size, making later positions stale.

This fix implements offset tracking to adjust positions correctly:
- Track cumulative byte offsets per file in a hash table
- Measure actual file size change before/after each update
- Adjust positions by the cumulative offset for subsequent updates
- Export flush-pending-updates! to reset offsets between tests

The key insight is that we must measure the actual file size change rather
than calculating it from span/new-str, because different update functions
(like update-file-empty) replace different amounts of content than the
span indicates.

Adds comprehensive tests for:
- Multiple @expect forms with varying output sizes
- Many (10) @expect forms to stress test offset accumulation
- Updating stale expectations (non-empty braces)
- Regular quoted string syntax (non-at-exp) multi-updates