### PR TITLE
Docs: improve README and Scribble manual with at-exp examples and expanded API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,66 @@
 inspired by [Jane Street's `expect_test` for OCaml](https://github.com/janestreet/ppx_expect)
 and the [`expect-test` crate](https://github.com/rust-analyzer/expect-test) for Rust.
 
-Expect tests record the output of expressions directly in the source file.
-Each `expect` form expands to a small RackUnit test that compares the
-captured output against the recorded expectation. When the environment
-variable `RECSPECS_UPDATE` is set, failing expectations are automatically
-updated in the file instead of causing a failure.
+Expect tests are especially useful when the clearest behavior to check is
+what a function prints. Put the code that produces output next to the output
+you expect, run the file with `raco test`, and review the saved transcript
+when behavior changes. Each `expect` form expands to a small RackUnit test.
+When the environment variable `RECSPECS_UPDATE` is set, failing expectations
+are automatically updated in the file instead of causing a failure.
+
+For readable multi-line examples, use Racket's @-expression reader by
+starting a test file with `#lang at-exp racket`. Then write `@expect[...]`:
+the expression to run goes in square brackets, and the expected output goes
+in braces.
+
+## Getting started
+
+```racket
+#lang at-exp racket
+(require recspecs)
+
+(define (greet name)
+  (printf "Hello, ~a!\n" name))
+
+@expect[(greet "Ada")]{
+Hello, Ada!
+}
+```
+
+The `@expect[...] { ... }` shape is just reader syntax for an ordinary
+`expect` call. It lets the expected output look like the text your program
+prints, instead of a string with `\n` escapes.
+
+A slightly larger example can still stay direct:
+
+```racket
+#lang at-exp racket
+(require recspecs)
+
+(define (print-shopping-list items)
+  (for ([item items]
+        [n (in-naturals 1)])
+    (printf "~a. ~a\n" n item)))
+
+@expect[(print-shopping-list '("apples" "bread" "coffee"))]{
+1. apples
+2. bread
+3. coffee
+}
+```
+
+Run the file normally:
+
+```console
+$ raco test shopping-list-test.rkt
+```
+
+When the output intentionally changes, update the recorded output and then
+review the file:
+
+```console
+$ RECSPECS_UPDATE=1 raco test shopping-list-test.rkt
+```
 
 Additional forms mirror features from the OCaml and Rust libraries:
 
@@ -32,43 +87,41 @@ Additional forms mirror features from the OCaml and Rust libraries:
 * Set `RECSPECS_VERBOSE` or parameterize `recspecs-verbose?` to print
   captured output while tests run.
 * Pass `#:port 'stderr` to capture output from `current-error-port` in
-  `expect`, `expect-file`, `expect-exn`, or `capture-output`. Use `'both`
-  to capture from both output ports at once.
+  `expect`, `expect-file`, or `capture-output`. Use `'both` to capture from
+  both output ports at once.
 * Use `capture-output` to run a thunk and return its printed output.
 
-## Example
+The Scribble reference shows accepted keyword arguments and their defaults in
+each form signature.
 
-```racket
-#lang racket
-(require recspecs)
+## More common examples
 
-(expect
-  (begin
-    (displayln "hello")
-    (displayln (+ 1 2)))
-  "hello\n3\n")
-
-(expect (display "oops" (current-error-port))
-        "oops"
-        #:port 'stderr)
-
-(expect (begin
-          (display "warn" (current-error-port))
-          (display "out"))
-        "warnout"
-        #:port 'both)
-```
-
-Using @ expressions from `#lang at-exp` can make multi-line output
-easier to write:
+Use `expect/print` when you want to check a returned value rather than
+hand-writing a call to `display` or `printf`:
 
 ```racket
 #lang at-exp racket
 (require recspecs)
 
-@expect[(begin (displayln "hello") (displayln (+ 1 2)))]{
-hello
-3}
+@expect/print[(map string-upcase '("red" "blue"))]{
+'("RED" "BLUE")
+}
+```
+
+Use `expect-exn` when the expected behavior is an exception message:
+
+```racket
+#lang at-exp racket
+(require recspecs)
+
+(define (parse-port n)
+  (unless (and (integer? n) (<= 0 n 65535))
+    (raise-user-error 'parse-port "expected an integer from 0 to 65535"))
+  n)
+
+@expect-exn[(parse-port 70000)]{
+parse-port: expected an integer from 0 to 65535
+}
 ```
 
 Mark code that should not run with `expect-unreachable`:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Automatically print a value before comparing:
 Check an interactive shell transcript:
 
 ```racket
+#lang at-exp racket
+(require recspecs/shell)
+
 @expect/shell["cat"]{
 > hi
 hi

--- a/README.md
+++ b/README.md
@@ -165,7 +165,12 @@ Automatically print a value before comparing:
 
 ```racket
 (expect/print (+ 1 2) "3")
-(expect/pretty '(1 2 3) "(1 2 3)\n")
+(expect/pretty '(1 2 3) "'(1 2 3)\n")
+```
+
+Check an interactive shell transcript:
+
+```racket
 @expect/shell["cat"]{
 > hi
 hi
@@ -207,15 +212,14 @@ result:
 (commit-expectation! e)
 ```
 
-`with-expectation` can also wrap other recspecs forms. The recorded output is
-available via @racket[expectation-out]:
+The recorded output is available via `expectation-out`:
 
 ```racket
 (define log (make-expectation))
 (with-expectation log
-  (expect (display "hi") "hi"))
+  (display "hi"))
 (commit-expectation! log)
-(displayln (expectation-out log)) ; prints ""
+(displayln (expectation-out log)) ; prints "hi"
 ```
 
 Run the file with `raco test` (or any RackUnit runner) to execute the
@@ -257,4 +261,3 @@ This library is new but relatively-feature complete. However, it hasn't
 been used in anger, so lots of things might change.
 
 Almost all the code here was written by the OpenAI Codex tool
-

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -426,9 +426,10 @@ Replace the entire file at @racket[path] with @racket[new-str].
 @section{Shell Commands}
 @defmodule[recspecs/shell]
 
-The @racket[recspecs/shell] module provides tools for testing interactive shell 
-commands, inspired by the Unix @exec{expect} tool. It supports both simple transcript-based 
-testing and advanced pattern-based automation.
+The @racket[recspecs/shell] module provides tools for testing interactive
+shell commands, inspired by the Unix @exec{expect} tool. Use
+@racket[expect/shell] for transcript-based tests. The module also exposes
+experimental pattern-matching helpers for lower-level interactive control.
 
 @subsection{Basic Shell Testing}
 
@@ -451,7 +452,7 @@ the subprocess exit code. @racket[#:port] accepts @racket['stdout],
 @racket[environment-variables?] value. @racket[#:match] accepts
 @racket['equal], @racket['contains], or @racket['regexp].
 }
-@racketblock[
+@racketblock[#:lang at-exp racket
   (require recspecs/shell)
   @expect/shell["cat"]{
   > hi
@@ -461,10 +462,17 @@ the subprocess exit code. @racket[#:port] accepts @racket['stdout],
   }
 ]
 
-@subsection{Pattern-Based Shell Automation}
+@subsection{Experimental Pattern Helpers}
 
-For complex interactive scenarios, @racket[expect/shell/patterns] provides a 
-declarative pattern-matching approach similar to the Unix @exec{expect} tool.
+The pattern interface is experimental. Prefer @racket[expect/shell] for tests
+that can be represented as a transcript. The lower-level pattern helpers are
+useful for testing pattern parsing and for experimenting with interactive
+control, but the current implementation does not implement timeout or EOF
+pattern matching, and a pattern that never matches can block.
+
+@racket[expect/shell/patterns] accepts exact, regexp, and glob patterns plus
+actions that send input, continue, retry, raise an error, or call a custom
+procedure:
 
 @defform[(expect/shell/patterns cmd-expr
                                   [#:strict? strict?-expr #f]
@@ -480,99 +488,12 @@ declarative pattern-matching approach similar to the Unix @exec{expect} tool.
                   (code:line (error message-expr))
                   procedure-expr])]{
 
-Runs @racket[cmd-expr] as an interactive subprocess and processes output using
-pattern/action pairs. Each pattern is matched against the accumulated output, and
-when matched, the corresponding action is executed.
-
-@bold{Patterns:}
-@itemlist[
-@item{@racket[string-expr] or @racket[(exact string-expr)] — Exact string matching}
-@item{@racket[(regex regex-expr)] — Regular expression matching with capture group support}
-@item{@racket[(glob glob-string-expr)] — Glob pattern matching with @litchar{*} and @litchar{?} wildcards}
-]
-
-@bold{Actions:}
-@itemlist[
-@item{@racket[(send-input text-expr)] — Send text as input to the process}
-@item{@racket[continue] — Proceed to the next pattern}
-@item{@racket[retry] — Retry the current pattern}
-@item{@racket[(error message-expr)] — Raise an error with the given message}
-@item{@racket[procedure-expr] — Call a custom procedure with session and variables}
-]
+Runs @racket[cmd-expr] as an interactive subprocess and processes
+pattern/action pairs in order. Each pattern is matched against accumulated
+output; when it matches, the action is executed. Regex captures are available
+for substitution in @racket[(send-input text-expr)] as @racket[$0],
+@racket[$1], and so on.
 }
-
-@bold{Examples:}
-
-Simple command interaction:
-@racketblock[
-  (expect/shell/patterns "bash"
-    ["$" (send-input "echo hello")]
-    ["hello" (send-input "exit")])]
-
-Using regex patterns:
-@racketblock[
-  (expect/shell/patterns "server"
-    [(regex #rx"Server started on port ([0-9]+)")
-     (send-input "connect")]
-    ["Connected" continue])]
-
-Glob patterns and error handling:
-@racketblock[
-  (expect/shell/patterns "deployment-script"
-    [(glob "*$ ") (send-input "deploy app")]
-    [(glob "*Success*") continue]
-    [(glob "*Error*") (error "Deployment failed")]
-    [(glob "*Warning*") continue])]
-
-Variable capture and substitution:
-@racketblock[
-  (expect/shell/patterns "bash"
-    ["$" (send-input "echo 'port: 8080'")]
-    [(regex #rx"port: ([0-9]+)") (send-input "connect $0")]
-    ["connected" (send-input "exit")])]
-
-@subsection{Advanced Pattern Features}
-
-@subsubsection{Variable Capture}
-
-When using @racket[(regex regex-expr)] patterns, capture groups are automatically 
-extracted and made available for variable substitution in subsequent actions. 
-Variables are referenced as @racket[$0], @racket[$1], @racket[$2], etc., where 
-@racket[$0] is the first capture group.
-
-@racketblock[
-  (expect/shell/patterns "date"
-    [(regex #rx"([A-Z][a-z]+) ([0-9]+)") 
-     (send-input "echo Month: $0, Day: $1")])]
-
-@subsubsection{Flow Control}
-
-@itemlist[
-@item{@racket[continue] — Advances to the next pattern in the sequence}
-@item{@racket[retry] — Repeats the current pattern (useful for polling)}
-@item{@racket[(error msg)] — Terminates with a controlled error}
-]
-
-@racketblock[
-  (expect/shell/patterns "build-system"
-    ["Building..." continue]
-    [(regex #rx"Progress: ([0-9]+)%") retry]  ; Keep polling
-    ["Build complete" continue]
-    [(glob "*failed*") (error "Build failed")])]
-
-@subsubsection{Custom Actions}
-
-For complex logic, actions can be procedures that receive the session state and captured variables:
-
-@racketblock[
-  (define (analyze-output session vars)
-    (if (> (length vars) 0)
-        (printf "Captured: ~a~n" (car vars))
-        (printf "No captures~n"))
-    'continue)
-
-  (expect/shell/patterns "analyzer"
-    [(regex #rx"Result: (.+)") analyze-output])]
 
 @subsection{Pattern Matching Reference}
 
@@ -581,8 +502,8 @@ For complex logic, actions can be procedures that receive the session state and 
 Tests whether @racket[pattern] matches @racket[text]. Returns three values:
 whether the pattern matched, updated variable list with any captures, and the text.
 
-This function underlies the pattern matching in @racket[expect/shell/patterns] and 
-can be used directly for testing pattern logic.
+This function underlies the pattern matching in @racket[expect/shell/patterns]
+and can be used directly for testing pattern logic.
 }
 
 @racketblock[
@@ -591,43 +512,6 @@ can be used directly for testing pattern logic.
   ; matched? => #t
   ; vars => '("8080")
 ]
-
-@subsection{Error Handling and Debugging}
-
-When patterns fail to match, @racket[expect/shell/patterns] reports details
-including:
-
-@itemlist[
-@item{The accumulated output at the time of failure}
-@item{The pattern that was being matched}
-@item{Suggestions for common issues}
-]
-
-For debugging complex interactions, enable verbose mode with @racket[recspecs-verbose?] 
-or the @tt{RECSPECS_VERBOSE} environment variable to see real-time output.
-
-@subsection{Migration from Basic Shell Testing}
-
-Existing @racket[expect/shell] tests can be gradually migrated to the pattern-based 
-approach for enhanced functionality:
-
-@racketblock[
-  ; Before: transcript-based
-  @expect/shell["interactive-app"]{
-  > start
-  Ready
-  > process data.txt
-  Processing...
-  Done
-  > quit
-  }
-
-  ; After: pattern-based
-  (expect/shell/patterns "interactive-app"
-    ["$" (send-input "start")]
-    ["Ready" (send-input "process data.txt")]
-    [(glob "*Processing*") continue]
-    ["Done" (send-input "quit")])]
 
 @subsection{Pattern and Action Structures}
 

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -25,7 +25,7 @@ RackUnit @racket[test-case]. You can run the file with @exec{raco test}:
 
 @verbatim|{raco test hello-test.rkt}|
 
-@section{Writing Readable Expectations with @tt{#lang at-exp racket}}
+@section[#:tag "at-exp"]{Writing Readable Expectations with @tt{#lang at-exp racket}}
 
 Most expect tests are easiest to read with Racket's @racketmodname[at-exp]
 reader. Start the file with @racketfont{#lang at-exp racket} instead of plain
@@ -114,13 +114,13 @@ Use @racket[expect/pretty] for data that is easier to inspect with
   (require recspecs)
 
   @expect/pretty['(shopping-list
-                  (item "apples")
-                  (item "bread")
-                  (item "coffee"))]{
+                  (item "apples" #:qty 2 #:aisle "produce")
+                  (item "bread" #:qty 1 #:aisle "bakery")
+                  (item "coffee" #:qty 1 #:aisle "dry goods"))]{
   '(shopping-list
-    (item "apples")
-    (item "bread")
-    (item "coffee"))
+    (item "apples" #:qty 2 #:aisle "produce")
+    (item "bread" #:qty 1 #:aisle "bakery")
+    (item "coffee" #:qty 1 #:aisle "dry goods"))
   }]
 
 @subsection{Testing Error Messages}
@@ -359,13 +359,12 @@ Evaluates the @racket[expr]s and appends anything printed to
 @racket[e]'s @racket[out] field. @racket[#:port] accepts @racket['stdout],
 @racket['stderr], or @racket['both].}
 
-You can wrap any of the expectation forms with @racket[with-expectation] and
-access the captured output with @racket[expectation-out]:
+The recorded output is available with @racket[expectation-out]:
 
 @racketblock[
   (define log (make-expectation))
   (with-expectation log
-    (expect (display "hi") "hi"))
+    (display "hi"))
   (commit-expectation! log)
   (displayln (expectation-out log))]
 
@@ -468,16 +467,13 @@ For complex interactive scenarios, @racket[expect/shell/patterns] provides a
 declarative pattern-matching approach similar to the Unix @exec{expect} tool.
 
 @defform[(expect/shell/patterns cmd-expr
-                                  [#:timeout timeout-expr 30]
                                   [#:strict? strict?-expr #f]
                                   [pattern action] ...)
          #:grammar
          ([pattern string-expr
                    (code:line (exact string-expr))
                    (code:line (regex regex-expr))
-                   (code:line (glob glob-string-expr))
-                   (code:line (timeout seconds-expr))
-                   (code:line eof)]
+                   (code:line (glob glob-string-expr))]
           [action (code:line (send-input text-expr))
                   (code:line continue)
                   (code:line retry)
@@ -493,8 +489,6 @@ when matched, the corresponding action is executed.
 @item{@racket[string-expr] or @racket[(exact string-expr)] — Exact string matching}
 @item{@racket[(regex regex-expr)] — Regular expression matching with capture group support}
 @item{@racket[(glob glob-string-expr)] — Glob pattern matching with @litchar{*} and @litchar{?} wildcards}
-@item{@racket[(timeout seconds-expr)] — Matches when the specified timeout is reached}
-@item{@racket[eof] — Matches when the process terminates}
 ]
 
 @bold{Actions:}
@@ -515,12 +509,11 @@ Simple command interaction:
     ["$" (send-input "echo hello")]
     ["hello" (send-input "exit")])]
 
-Using regex patterns with timeout:
+Using regex patterns:
 @racketblock[
-  (expect/shell/patterns "slow-server" #:timeout 60
-    [(regex #rx"Server started on port ([0-9]+)") 
+  (expect/shell/patterns "server"
+    [(regex #rx"Server started on port ([0-9]+)")
      (send-input "connect")]
-    [(timeout 30) (error "Server startup timeout")]
     ["Connected" continue])]
 
 Glob patterns and error handling:
@@ -567,17 +560,6 @@ Variables are referenced as @racket[$0], @racket[$1], @racket[$2], etc., where
     ["Build complete" continue]
     [(glob "*failed*") (error "Build failed")])]
 
-@subsubsection{Timeout Handling}
-
-Individual patterns can specify timeouts, and a global session timeout can be set:
-
-@racketblock[
-  (expect/shell/patterns "long-running-process" #:timeout 300
-    ["Starting..." continue]
-    [(timeout 60) (send-input "status")]  ; Check status after 1 minute
-    ["Progress: 100%" continue]
-    [(timeout 300) (error "Process timeout")])]
-
 @subsubsection{Custom Actions}
 
 For complex logic, actions can be procedures that receive the session state and captured variables:
@@ -612,8 +594,8 @@ can be used directly for testing pattern logic.
 
 @subsection{Error Handling and Debugging}
 
-When patterns fail to match or timeouts occur, @racket[expect/shell/patterns] provides 
-detailed error messages including:
+When patterns fail to match, @racket[expect/shell/patterns] reports details
+including:
 
 @itemlist[
 @item{The accumulated output at the time of failure}
@@ -669,14 +651,6 @@ Matches using regular expressions and captures groups for variable substitution.
 Matches using glob patterns with @litchar{*} and @litchar{?} wildcards.
 }
 
-@defstruct[pattern-timeout ([seconds number?])]{
-Triggers when the specified number of seconds have elapsed.
-}
-
-@defstruct[pattern-eof ()]{
-Triggers when the subprocess terminates or reaches end-of-file.
-}
-
 @defstruct[action-send-text ([text string?])]{
 Sends the specified text to the subprocess as input.
 }
@@ -697,9 +671,9 @@ Raises an error with the specified message.
 Executes a custom procedure with signature @racket[(-> shell-session? list? symbol?)].
 }
 
-@defproc[(shell-run-patterns [cmd (or/c string? (listof string?))] 
-                             [patterns (listof pattern-action?)] 
-                             [#:timeout timeout number? 30]) 
+@defproc[(shell-run-patterns [cmd (or/c string? (listof string?))]
+                             [patterns (listof pattern-action?)]
+                             [#:timeout timeout number? 30])
          void?]{
 Low-level function that runs the pattern-based shell interaction. This function 
 underlies @racket[expect/shell/patterns] and can be used for programmatic control.
@@ -718,11 +692,9 @@ underlies @racket[expect/shell/patterns] and can be used for programmatic contro
 
 @itemlist[
 @item{Use specific patterns to avoid false matches: prefer @racket[(exact "$ ")] over @racket["$"]}
-@item{Include timeout patterns for long-running operations}
 @item{Use @racket[continue] judiciously to handle intermediate output}
 @item{Capture important values with regex patterns for reuse}
 @item{Test pattern logic in isolation using @racket[match-pattern]}
 @item{Enable verbose mode during development for better visibility}
 @item{Consider the order of patterns carefully: more specific patterns should come before general ones}
-@item{Use @racket[eof] patterns to handle unexpected process termination gracefully}
 ]

--- a/recspecs/main.scrbl
+++ b/recspecs/main.scrbl
@@ -3,56 +3,198 @@
 @title{recspecs: Expect Testing for Racket}
 @defmodule[recspecs]
 
+@section{Getting Started}
+
+Recspecs is useful when the easiest way to check a program is to look at
+what it prints. Instead of writing assertions for every small value, you
+run the code and keep the expected transcript next to the code that
+produced it.
+
+A minimal test file looks like this:
+
+@racketblock[
+  (require recspecs)
+
+  (expect (displayln "hello")
+          "hello\n")]
+
 The @racket[expect] form captures anything printed to the current output
-port while evaluating an expression and compares it to a string literal
-stored directly in the source file.  Each use expands to a
-RackUnit @racket[test-case].  When the environment variable
-@tt{RECSPECS_UPDATE} is set and the expectation does not match, the file
-is rewritten with the new output instead of failing the test.  When
-@tt{RECSPECS_UPDATE} is not set and the expectation fails, a colorized
-diff is printed to help understand the mismatch. Updating can be
-restricted to a single test case by setting
-@tt{RECSPECS_UPDATE_TEST} to the name shown for that case.
+port while @racket[expr] runs. It compares that captured output to the
+expected string in the source file, and each @racket[expect] expands to a
+RackUnit @racket[test-case]. You can run the file with @exec{raco test}:
+
+@verbatim|{raco test hello-test.rkt}|
+
+@section{Writing Readable Expectations with @tt{#lang at-exp racket}}
+
+Most expect tests are easiest to read with Racket's @racketmodname[at-exp]
+reader. Start the file with @racketfont{#lang at-exp racket} instead of plain
+@racketfont{#lang racket}, then put @litchar|{@}| before @racket[expect]. The
+expression to run goes in square brackets, and the expected output goes in
+braces:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  @expect[(displayln "hello")]{
+  hello
+  }]
+
+The @litchar|{@}| form is just reader syntax for an ordinary function or
+macro call. The example above is equivalent to writing an @racket[expect]
+form with a string argument, but the expected output can be written as the
+text you want to see instead of as a string with @racket["\\n"] escapes.
+
+Here is a slightly more realistic example that checks a report:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  (define (print-shopping-list items)
+    (for ([item items]
+          [n (in-naturals 1)])
+      (printf "~a. ~a\n" n item)))
+
+  @expect[(print-shopping-list '("apples" "bread" "coffee"))]{
+  1. apples
+  2. bread
+  3. coffee
+  }]
+
+Use this style when the expected output has more than one line or when the
+literal output is clearer than a Racket string. For one-line output, a
+plain string is still fine.
+
+@section{Updating Recorded Output}
+
+When the output intentionally changes, rerun the test with
+@tt{RECSPECS_UPDATE} set. If an expectation does not match, recspecs
+rewrites the expectation in the source file with the new output instead of
+failing the test:
+
+@verbatim|{RECSPECS_UPDATE=1 raco test shopping-list-test.rkt}|
+
+After reviewing the rewritten file, run the tests normally again. Updating
+can be restricted to a single test case by setting @tt{RECSPECS_UPDATE_TEST}
+to the name shown for that case.
+
+@section{Common First Use Cases}
+
+@subsection{Testing Printed Output}
+
+Use @racket[expect] when the behavior you care about is what the code
+prints:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  (define (greet name)
+    (printf "Hello, ~a!\n" name))
+
+  @expect[(greet "Ada")]{
+  Hello, Ada!
+  }]
+
+@subsection{Testing Printed Values}
+
+Use @racket[expect/print] when you want to test the value an expression
+returns. Recspecs prints the value with @racket[print] before comparing it:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  @expect/print[(map string-upcase '("red" "blue"))]{
+  '("RED" "BLUE")
+  }]
+
+Use @racket[expect/pretty] for data that is easier to inspect with
+@racket[pretty-print]:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  @expect/pretty['(shopping-list
+                  (item "apples")
+                  (item "bread")
+                  (item "coffee"))]{
+  '(shopping-list
+    (item "apples")
+    (item "bread")
+    (item "coffee"))
+  }]
+
+@subsection{Testing Error Messages}
+
+Use @racket[expect-exn] when the expected behavior is an exception:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  (define (parse-port n)
+    (unless (and (integer? n) (<= 0 n 65535))
+      (raise-user-error 'parse-port "expected an integer from 0 to 65535"))
+    n)
+
+  @expect-exn[(parse-port 70000)]{
+  parse-port: expected an integer from 0 to 65535
+  }]
+
+@subsection{Capturing Output Without an Expectation}
+
+Use @racket[capture-output] when you need the printed text as a string for
+some other assertion or helper:
+
+@racketblock[
+  (require recspecs rackunit)
+
+  (define out
+    (capture-output
+     (lambda ()
+       (display "ready"))))
+
+  (check-equal? out "ready")]
+
+@section{Daily Workflow and Options}
 
 Verbose mode can be enabled by setting @tt{RECSPECS_VERBOSE} or by
-parameterizing @racket[recspecs-verbose?]. When enabled, captured
-output is echoed to the real output port as it is produced.
-For example:
+parameterizing @racket[recspecs-verbose?]. When enabled, captured output is
+echoed to the real output port as it is produced:
 
 @verbatim|{RECSPECS_VERBOSE=1 raco test my-test.rkt}|
 
 For Emacs users, the accompanying @filepath{emacs/recspecs.el} file
-provides @racketfont{recspecs-update-at-point}, which runs the current
-file under @exec{racket-test} with those environment variables set for
-the expectation at the cursor position. After the test finishes the
-buffer is automatically reverted so that any updated expectations are
-reloaded from disk.
+provides @racketfont{recspecs-update-at-point}, which runs the current file
+under @exec{racket-test} with the update environment variables set for the
+expectation at the cursor position. After the test finishes the buffer is
+automatically reverted so that any updated expectations are reloaded from
+disk.
 
-Use @racket[#:port 'stderr] with @racket[expect], @racket[expect-file],
-@racket[expect-exn], or @racket[capture-output] to record output written
-to the current error port instead of the output port. Pass
-@racket['both] to capture from both ports simultaneously.
+Use @racket[#:port] @racket['stderr] with @racket[expect], @racket[expect-file], or
+@racket[capture-output] to record output written to the current error port
+instead of the output port. Pass @racket['both] to capture from both ports
+simultaneously:
+
+@racketblock[#:lang at-exp racket
+  (require recspecs)
+
+  @expect[(display "oops" (current-error-port))
+          #:port 'stderr]{
+  oops
+  }]
 
 Output can be transformed before it is compared by parameterizing
 @racket[recspecs-output-filter]. The parameter holds a procedure that
-receives the captured string and returns a new string used for the
-comparison and when updating:
+receives the captured string and returns a new string used for comparison
+and updating. For example, trim incidental surrounding whitespace:
 
-@racketblock[
-  (parameterize ([recspecs-output-filter
-                  (lambda (s) (regexp-replace* #px"[0-9]+" s ""))])
-    (expect (display "v1.2") "v."))]
-@racketblock[
-  (parameterize ([recspecs-output-filter string-upcase])
-    (expect (display "ok") "OK"))]
 @racketblock[
   (parameterize ([recspecs-output-filter string-trim])
     (expect (display "  hi  ") "hi"))]
 
 The thunk that performs the test is executed via the procedure stored in
-@racket[recspecs-runner].  The default simply calls the thunk, but it can
-be replaced to control the runtime context. For example, limit memory
-usage with a new custodian and redirect the error port:
+@racket[recspecs-runner]. The default simply calls the thunk, but advanced
+tests can replace it to control the runtime context. For example, you can
+limit memory usage with a new custodian and redirect the error port:
 
 @racketblock[
   (parameterize ([recspecs-runner
@@ -67,20 +209,26 @@ usage with a new custodian and redirect the error port:
               (make-bytes (* 2 1024 1024)))
             "oops"))]
 
-@defform[(expect expr expected-str ... maybe-keywords)
-         #:grammar
-         ([maybe-keywords (code:line)
-                          (code:line #:strict? strict?-expr)
-                          (code:line #:port port-expr)
-                          (code:line #:match match-expr)])]{
-Evaluates @racket[expr] and checks that the captured output is equal to
-the concatenation of @racket[expected-str]s. If they differ and
-@tt{RECSPECS_UPDATE} is set, the expectation string in the source file
-is replaced with the new value.  Otherwise the test case fails.
 
-Use @racket[#:match 'contains] to check that the output contains the
-expected string as a substring, or @racket[#:match 'regexp] to treat the
-expected string as a regular expression.
+@section{Reference}
+@defform[(expect expr expected-str ...
+                 [#:strict? strict?-expr #f]
+                 [#:port port-expr 'stdout]
+                 [#:match match-expr 'equal])]{
+Evaluates @racket[expr] and checks that the captured output is equal to
+the concatenation of @racket[expected-str]s.
+
+@racket[#:strict?] controls whitespace comparison. When false, comparison
+ignores surrounding whitespace and common indentation. When true, comparison
+uses exact string equality. @racket[#:port] accepts @racket['stdout],
+@racket['stderr], or @racket['both]. @racket[#:match] accepts
+@racket['equal], @racket['contains], or @racket['regexp].
+
+If the expectation differs and @tt{RECSPECS_UPDATE} is set, the expectation
+string in the source file is replaced with the new value. Otherwise the test
+case fails. Update mode is skipped for @racket['contains] and
+@racket['regexp] because recspecs cannot infer the intended substring or
+regular expression from the actual output.
 
 @racketblock[
   (expect (display "hello world") "hello" #:match 'contains)
@@ -101,21 +249,35 @@ expectations:
   hello
   3}]
 
-@defform[(expect/print expr expected-str ...)]{
+@defform[(expect/print expr expected-str ...
+                       [#:strict? strict?-expr #f]
+                       [#:port port-expr 'stdout]
+                       [#:match match-expr 'equal])]{
 Like @racket[expect], but the result of @racket[expr] is printed with
-@racket[print] before comparison.  This is shorthand for
-@racket[(expect (print expr) expected-str ...)].
+@racket[print] before comparison. This is shorthand for
+@racket[(expect (print expr) expected-str ...)]. It accepts the same
+@racket[#:strict?], @racket[#:port], and @racket[#:match] keywords as
+@racket[expect], with defaults shown in the form above.
 }
 
-@defform[(expect/pretty expr expected-str ...)]{
+@defform[(expect/pretty expr expected-str ...
+                        [#:strict? strict?-expr #f]
+                        [#:port port-expr 'stdout]
+                        [#:match match-expr 'equal])]{
 Like @racket[expect/print], but uses @racket[pretty-print] to output the
-result.  The newline produced by @racket[pretty-print] is included in the
-expectation.
+result. The newline produced by @racket[pretty-print] is included in the
+expectation. It accepts the same @racket[#:strict?], @racket[#:port], and
+@racket[#:match] keywords as @racket[expect], with defaults shown in the
+form above.
 }
 
-@defform[(expect-file expr path-str)]{
+@defform[(expect-file expr path-str
+                       [#:strict? strict?-expr #f]
+                       [#:port port-expr 'stdout])]{
 Reads the expectation from @racket[path-str] instead of embedding it in the
 source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.
+@racket[#:port] accepts @racket['stdout], @racket['stderr], or
+@racket['both].
 }
 @racketblock[
   (expect-file
@@ -124,10 +286,14 @@ source. The file is replaced with new output when @tt{RECSPECS_UPDATE} is set.
       (displayln "world"))
     "expected.txt")]
 
-@defform[(expect-exn expr expected-str ...)]{
+@defform[(expect-exn expr expected-str ...
+                      [#:strict? strict?-expr #f]
+                      [#:port port-expr 'stdout])]{
 Checks that @racket[expr] raises an exception whose message matches the
 concatenation of @racket[expected-str]s. The message is updated when
-update mode is enabled.
+update mode is enabled. @racket[#:port] is accepted for consistency with
+the other expectation forms; @racket[expect-exn] compares the exception
+message rather than captured output.
 }
 @racketblock[
   (expect-exn (raise-user-error "bad")
@@ -142,7 +308,7 @@ failing.
   (when #f
     (expect-unreachable (displayln "never")))]
 
-@defproc[(capture-output [thunk (-> any/c)] [#:port port any/c 'stdout]) string?]{
+@defproc[(capture-output [thunk (-> any/c)] [#:port port (symbols 'stdout 'stderr 'both) 'stdout]) string?]{
 Runs @racket[thunk] and returns everything printed to the selected port(s).
 When @racket[port] is @racket['stderr], the current error port is captured
 instead of the output port. Pass @racket['both] to capture from both ports.
@@ -188,9 +354,10 @@ append to @racket[out].}
 
 @defproc[(skip-expectation! [e expectation?]) void?]{Mark @racket[e] as skipped.}
 
-@defform[(with-expectation e expr ...)]{
+@defform[(with-expectation e [#:port port-expr 'stdout] expr ...)]{
 Evaluates the @racket[expr]s and appends anything printed to
-@racket[e]'s @racket[out] field.}
+@racket[e]'s @racket[out] field. @racket[#:port] accepts @racket['stdout],
+@racket['stderr], or @racket['both].}
 
 You can wrap any of the expectation forms with @racket[with-expectation] and
 access the captured output with @racket[expectation-out]:
@@ -243,7 +410,9 @@ substring and regexp patterns cannot be auto-derived from output.
           [#:port port (symbols 'stdout 'stderr 'both) 'stdout])
          void?]{
 Like @racket[run-expect] but expects @racket[thunk] to raise an
-exception whose message matches @racket[expected].
+exception whose message matches @racket[expected]. The @racket[#:port]
+keyword is accepted for consistency with expectation forms, but the
+comparison is against the exception message.
 }
 
 @defproc[(update-file-entire
@@ -264,25 +433,24 @@ testing and advanced pattern-based automation.
 
 @subsection{Basic Shell Testing}
 
-@defform[(expect/shell cmd-expr option ... expected-str ...)
-         #:grammar
-         ([option (code:line #:strict? strict?-expr)
-                  (code:line #:status status-expr)
-                  (code:line #:port port-expr)
-                  (code:line #:env env-expr)
-                  (code:line #:match match-expr)])]{
+@defform[(expect/shell cmd-expr
+                         [#:strict? strict?-expr #f]
+                         [#:status status-expr #f]
+                         [#:port port-expr 'stdout]
+                         [#:env env-expr #f]
+                         [#:match match-expr 'equal]
+                         expected-str ...)]{
 Run @racket[cmd-expr] as a subprocess and compare the interaction
-against @racket[expected-str ...].  Lines in the expectation that begin
+against @racket[expected-str ...]. Lines in the expectation that begin
 with @litchar{>} are sent to the process as input (without the prompt).
 The command's responses are captured and the full transcript is checked
 against the expectation.
 
-@racket[#:status] checks the subprocess exit code (e.g., @racket[0] for
-success). @racket[#:port] selects which stream to read
-(@racket['stdout], @racket['stderr], or @racket['both]).
-@racket[#:env] accepts an @racket[environment-variables?] value to set
-the subprocess environment.  @racket[#:match] controls comparison mode
-(@racket['equal], @racket['contains], or @racket['regexp]).
+@racket[#:status] accepts an exact integer, such as @racket[0], to check
+the subprocess exit code. @racket[#:port] accepts @racket['stdout],
+@racket['stderr], or @racket['both]. @racket[#:env] accepts an
+@racket[environment-variables?] value. @racket[#:match] accepts
+@racket['equal], @racket['contains], or @racket['regexp].
 }
 @racketblock[
   (require recspecs/shell)
@@ -299,11 +467,12 @@ the subprocess environment.  @racket[#:match] controls comparison mode
 For complex interactive scenarios, @racket[expect/shell/patterns] provides a 
 declarative pattern-matching approach similar to the Unix @exec{expect} tool.
 
-@defform[(expect/shell/patterns cmd-expr option ... [pattern action] ...)
+@defform[(expect/shell/patterns cmd-expr
+                                  [#:timeout timeout-expr 30]
+                                  [#:strict? strict?-expr #f]
+                                  [pattern action] ...)
          #:grammar
-         ([option (code:line #:timeout timeout-expr)
-                  (code:line #:strict? strict?-expr)]
-          [pattern string-expr
+         ([pattern string-expr
                    (code:line (exact string-expr))
                    (code:line (regex regex-expr))
                    (code:line (glob glob-string-expr))
@@ -315,15 +484,9 @@ declarative pattern-matching approach similar to the Unix @exec{expect} tool.
                   (code:line (error message-expr))
                   procedure-expr])]{
 
-Runs @racket[cmd-expr] as an interactive subprocess and processes output using 
-pattern/action pairs. Each pattern is matched against the accumulated output, and 
+Runs @racket[cmd-expr] as an interactive subprocess and processes output using
+pattern/action pairs. Each pattern is matched against the accumulated output, and
 when matched, the corresponding action is executed.
-
-@bold{Options:}
-@itemlist[
-@item{@racket[#:timeout] — Sets the default timeout in seconds for the entire session (default: 30)}
-@item{@racket[#:strict?] — Controls whether whitespace normalization is applied (default: @racket[#f])}
-]
 
 @bold{Patterns:}
 @itemlist[


### PR DESCRIPTION
### Motivation

- Make expect tests easier to read and author by documenting `#lang at-exp racket` usage with concrete `@expect` examples.
- Clarify how updating, whitespace handling, output ports, match modes, and shell transcripts fit into the normal recspecs workflow.
- Give the Scribble manual a fuller API reference without advertising behavior beyond what the current implementation supports.

### Description

- Expanded `README.md` with a getting-started flow, multi-line at-exp examples, update-mode usage, and corrected examples for `expect/pretty`, shell transcripts, and `with-expectation`.
- Reworked `recspecs/main.scrbl` into a more approachable manual with introductory examples, update workflow notes, common use cases, and reference signatures with documented defaults.
- Added a stable Scribble tag for the at-exp section so multi-page documentation renders with a short generated filename.
- Tightened shell-pattern documentation to focus on currently supported exact, regexp, glob, and action forms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26f3a3b4748328b645b053efc3edc3)
